### PR TITLE
Lauwsj/activity storage

### DIFF
--- a/src/main/java/gomedic/MainApp.java
+++ b/src/main/java/gomedic/MainApp.java
@@ -56,7 +56,7 @@ public class MainApp extends Application {
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
-        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookPersonFilePath());
+        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookRootFilePath());
         storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         initLogging(config);

--- a/src/main/java/gomedic/logic/Logic.java
+++ b/src/main/java/gomedic/logic/Logic.java
@@ -36,9 +36,9 @@ public interface Logic {
     ObservableList<Person> getFilteredPersonList();
 
     /**
-     * Returns the user prefs' address book file path.
+     * Returns the user prefs' address root file path.
      */
-    Path getAddressBookFilePath();
+    Path getAddressBookRootFilePath();
 
     /**
      * Returns the user prefs' GUI settings.

--- a/src/main/java/gomedic/logic/LogicManager.java
+++ b/src/main/java/gomedic/logic/LogicManager.java
@@ -65,7 +65,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Path getAddressBookFilePath() {
+    public Path getAddressBookRootFilePath() {
         return model.getAddressBookDataRootFilePath();
     }
 

--- a/src/main/java/gomedic/logic/LogicManager.java
+++ b/src/main/java/gomedic/logic/LogicManager.java
@@ -66,7 +66,7 @@ public class LogicManager implements Logic {
 
     @Override
     public Path getAddressBookFilePath() {
-        return model.getAddressBookPersonFilePath();
+        return model.getAddressBookDataRootFilePath();
     }
 
     @Override

--- a/src/main/java/gomedic/model/Model.java
+++ b/src/main/java/gomedic/model/Model.java
@@ -37,12 +37,22 @@ public interface Model {
     /**
      * Returns the user prefs' address book file path.
      */
-    Path getAddressBookPersonFilePath();
+    Path getAddressBookDataRootFilePath();
 
     /**
      * Sets the user prefs' address book file path.
      */
-    void setAddressBookPersonFilePath(Path addressBookFilePath);
+    void setAddressBookDataRootFilePath(Path addressBookDataRootFilePath);
+
+    /**
+     * Returns the path to persons.json.
+     */
+    Path getAddressBookPersonsFilePath();
+
+    /**
+     * Returns the path to activities.json.
+     */
+    Path getAddressBookActivitiesFilePath();
 
     /** Returns the AddressBook */
     ReadOnlyAddressBook getAddressBook();

--- a/src/main/java/gomedic/model/Model.java
+++ b/src/main/java/gomedic/model/Model.java
@@ -44,16 +44,6 @@ public interface Model {
      */
     void setAddressBookDataRootFilePath(Path addressBookDataRootFilePath);
 
-    /**
-     * Returns the path to persons.json.
-     */
-    Path getAddressBookPersonsFilePath();
-
-    /**
-     * Returns the path to activities.json.
-     */
-    Path getAddressBookActivitiesFilePath();
-
     /** Returns the AddressBook */
     ReadOnlyAddressBook getAddressBook();
 

--- a/src/main/java/gomedic/model/ModelManager.java
+++ b/src/main/java/gomedic/model/ModelManager.java
@@ -23,6 +23,10 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    public ModelManager() {
+        this(new AddressBook(), new UserPrefs());
+    }
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -35,10 +39,6 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-    }
-
-    public ModelManager() {
-        this(new AddressBook(), new UserPrefs());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -66,14 +66,24 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Path getAddressBookPersonFilePath() {
+    public Path getAddressBookDataRootFilePath() {
+        return userPrefs.getAddressBookRootFilePath();
+    }
+
+    @Override
+    public void setAddressBookDataRootFilePath(Path addressBookDataRootFilePath) {
+        requireNonNull(addressBookDataRootFilePath);
+        userPrefs.setAddressBookDataFileRootPath(addressBookDataRootFilePath);
+    }
+
+    @Override
+    public Path getAddressBookPersonsFilePath() {
         return userPrefs.getAddressBookPersonFilePath();
     }
 
     @Override
-    public void setAddressBookPersonFilePath(Path addressBookPersonFilePath) {
-        requireNonNull(addressBookPersonFilePath);
-        userPrefs.setAddressBookPersonFilePath(addressBookPersonFilePath);
+    public Path getAddressBookActivitiesFilePath() {
+        return userPrefs.getAddressBookActivityFilePath();
     }
 
     //=========== AddressBook ================================================================================
@@ -106,13 +116,19 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void updateFilteredPersonList(Predicate<Person> predicate) {
+        requireNonNull(predicate);
+        filteredPersons.setPredicate(predicate);
+    }
+
+    //=========== Filtered Person List Accessors =============================================================
+
+    @Override
     public void setPerson(Person target, Person editedPerson) {
         CollectionUtil.requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
     }
-
-    //=========== Filtered Person List Accessors =============================================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
@@ -121,12 +137,6 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return filteredPersons;
-    }
-
-    @Override
-    public void updateFilteredPersonList(Predicate<Person> predicate) {
-        requireNonNull(predicate);
-        filteredPersons.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/gomedic/model/ModelManager.java
+++ b/src/main/java/gomedic/model/ModelManager.java
@@ -76,16 +76,6 @@ public class ModelManager implements Model {
         userPrefs.setAddressBookDataFileRootPath(addressBookDataRootFilePath);
     }
 
-    @Override
-    public Path getAddressBookPersonsFilePath() {
-        return userPrefs.getAddressBookPersonFilePath();
-    }
-
-    @Override
-    public Path getAddressBookActivitiesFilePath() {
-        return userPrefs.getAddressBookActivityFilePath();
-    }
-
     //=========== AddressBook ================================================================================
 
     @Override

--- a/src/main/java/gomedic/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/gomedic/model/ReadOnlyUserPrefs.java
@@ -11,7 +11,9 @@ public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
 
-    Path getAddressBookPersonFilePath();
-
     Path getAddressBookActivityFilePath();
+
+    Path getAddressBookRootFilePath();
+
+    Path getAddressBookPersonFilePath();
 }

--- a/src/main/java/gomedic/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/gomedic/model/ReadOnlyUserPrefs.java
@@ -11,9 +11,5 @@ public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
 
-    Path getAddressBookActivityFilePath();
-
     Path getAddressBookRootFilePath();
-
-    Path getAddressBookPersonFilePath();
 }

--- a/src/main/java/gomedic/model/UserPrefs.java
+++ b/src/main/java/gomedic/model/UserPrefs.java
@@ -14,15 +14,8 @@ import gomedic.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     public static final String ROOT_FOLDER = "data";
-    private Path addressBookDataFileRootPath = Paths.get(ROOT_FOLDER);
-    private final Path addressBookPersonsFilePath = Paths.get(
-            getAddressBookRootFilePath().toString(),
-            "persons.json");
-    private final Path addressBookActivityFilePath = Paths.get(
-            getAddressBookRootFilePath().toString(),
-            "activities.json");
+    private Path addressBookDataFileRootPath = Paths.get(ROOT_FOLDER, "addressbook.json");
     private GuiSettings guiSettings = new GuiSettings();
-
 
     /**
      * Creates a {@code UserPrefs} with the prefs in {@code userPrefs}.
@@ -44,7 +37,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
-        setAddressBookDataFileRootPath(newUserPrefs.getAddressBookPersonFilePath());
+        setAddressBookDataFileRootPath(newUserPrefs.getAddressBookRootFilePath());
     }
 
     public void setAddressBookDataFileRootPath(Path addressBookDataFileRootPath) {
@@ -59,16 +52,6 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         this.guiSettings = guiSettings;
-    }
-
-    @Override
-    public Path getAddressBookPersonFilePath() {
-        return addressBookPersonsFilePath;
-    }
-
-    @Override
-    public Path getAddressBookActivityFilePath() {
-        return addressBookActivityFilePath;
     }
 
     @Override
@@ -98,7 +81,6 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     @Override
     public String toString() {
-        // TODO : Integrate Activity file path
         return "Gui Settings : " + guiSettings
                 + "\nLocal data file location : " + addressBookDataFileRootPath;
     }

--- a/src/main/java/gomedic/model/UserPrefs.java
+++ b/src/main/java/gomedic/model/UserPrefs.java
@@ -13,15 +13,16 @@ import gomedic.commons.core.GuiSettings;
  */
 public class UserPrefs implements ReadOnlyUserPrefs {
 
-    private final Path addressBookActivityFilePath = Paths.get("data", "activities.json");
-    private Path addressBookPersonFilePath = Paths.get("data", "persons.json");
+    public static final String ROOT_FOLDER = "data";
+    private Path addressBookDataFileRootPath = Paths.get(ROOT_FOLDER);
+    private final Path addressBookPersonsFilePath = Paths.get(
+            getAddressBookRootFilePath().toString(),
+            "persons.json");
+    private final Path addressBookActivityFilePath = Paths.get(
+            getAddressBookRootFilePath().toString(),
+            "activities.json");
     private GuiSettings guiSettings = new GuiSettings();
 
-    /**
-     * Creates a {@code UserPrefs} with default values.
-     */
-    public UserPrefs() {
-    }
 
     /**
      * Creates a {@code UserPrefs} with the prefs in {@code userPrefs}.
@@ -32,12 +33,23 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     }
 
     /**
+     * Creates a {@code UserPrefs} with default values.
+     */
+    public UserPrefs() {
+    }
+
+    /**
      * Resets the existing data of this {@code UserPrefs} with {@code newUserPrefs}.
      */
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
-        setAddressBookPersonFilePath(newUserPrefs.getAddressBookPersonFilePath());
+        setAddressBookDataFileRootPath(newUserPrefs.getAddressBookPersonFilePath());
+    }
+
+    public void setAddressBookDataFileRootPath(Path addressBookDataFileRootPath) {
+        requireNonNull(addressBookDataFileRootPath);
+        this.addressBookDataFileRootPath = addressBookDataFileRootPath;
     }
 
     public GuiSettings getGuiSettings() {
@@ -51,17 +63,17 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     @Override
     public Path getAddressBookPersonFilePath() {
-        return addressBookPersonFilePath;
-    }
-
-    public void setAddressBookPersonFilePath(Path addressBookPersonFilePath) {
-        requireNonNull(addressBookPersonFilePath);
-        this.addressBookPersonFilePath = addressBookPersonFilePath;
+        return addressBookPersonsFilePath;
     }
 
     @Override
     public Path getAddressBookActivityFilePath() {
         return addressBookActivityFilePath;
+    }
+
+    @Override
+    public Path getAddressBookRootFilePath() {
+        return addressBookDataFileRootPath;
     }
 
     @Override
@@ -76,18 +88,18 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
-                && addressBookPersonFilePath.equals(o.addressBookPersonFilePath);
+                && addressBookDataFileRootPath.equals(o.addressBookDataFileRootPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, addressBookPersonFilePath);
+        return Objects.hash(guiSettings, addressBookDataFileRootPath);
     }
 
     @Override
     public String toString() {
         // TODO : Integrate Activity file path
         return "Gui Settings : " + guiSettings
-                + "\nLocal data file location : " + addressBookPersonFilePath;
+                + "\nLocal data file location : " + addressBookDataFileRootPath;
     }
 }

--- a/src/main/java/gomedic/model/activity/ActivityId.java
+++ b/src/main/java/gomedic/model/activity/ActivityId.java
@@ -25,6 +25,16 @@ public class ActivityId extends Id {
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @param id Integer from 1 to 999
+     */
+    public ActivityId(String id) {
+        super(Integer.parseInt(id.substring(1)), ACTIVITY_PREFIX);
+        AppUtil.checkArgument(isValidActivityId(this), MESSAGE_CONSTRAINTS);
+    }
+
+    /**
      * Returns true if a given stringId is a valid activity valid id.
      * Valid if integer is 3 digit, from 1 to 999, prefix is A.
      *
@@ -32,8 +42,19 @@ public class ActivityId extends Id {
      * @return true if valid, else false.
      */
     public static boolean isValidActivityId(Id id) {
-        int number = Integer.parseInt(id.toString().substring(1));
-        Character prefix = id.toString().charAt(0);
+        return isValidActivityId(id.toString());
+    }
+
+    /**
+     * Returns true if a given stringId is a valid activity valid id.
+     * Valid if integer is 3 digit, from 1 to 999, prefix is A.
+     *
+     * @param aid String.
+     * @return true if valid, else false.
+     */
+    public static boolean isValidActivityId(String aid) {
+        int number = Integer.parseInt(aid.substring(1));
+        Character prefix = aid.charAt(0);
         boolean isValidPrefix = prefix.equals(ACTIVITY_PREFIX);
 
         return isValidId(number, prefix) && isValidPrefix;

--- a/src/main/java/gomedic/model/activity/ActivityId.java
+++ b/src/main/java/gomedic/model/activity/ActivityId.java
@@ -27,7 +27,7 @@ public class ActivityId extends Id {
     /**
      * {@inheritDoc}
      *
-     * @param id Integer from 1 to 999
+     * @param id a string of format "PDDD", where "P" is an alphabetic character and "D" is a decimal number
      */
     public ActivityId(String id) {
         super(Integer.parseInt(id.substring(1)), ACTIVITY_PREFIX);

--- a/src/main/java/gomedic/model/activity/ActivityId.java
+++ b/src/main/java/gomedic/model/activity/ActivityId.java
@@ -53,6 +53,10 @@ public class ActivityId extends Id {
      * @return true if valid, else false.
      */
     public static boolean isValidActivityId(String aid) {
+        if (!isValidIdFormat(aid)) {
+            return false;
+        }
+
         int number = Integer.parseInt(aid.substring(1));
         Character prefix = aid.charAt(0);
         boolean isValidPrefix = prefix.equals(ACTIVITY_PREFIX);

--- a/src/main/java/gomedic/model/activity/Description.java
+++ b/src/main/java/gomedic/model/activity/Description.java
@@ -31,7 +31,7 @@ public class Description {
     /**
      * @return true for text that has less than max_char
      */
-    public boolean isValidDescription(String text) {
+    public static boolean isValidDescription(String text) {
         return text.length() <= MAX_CHAR;
     }
 

--- a/src/main/java/gomedic/model/activity/Title.java
+++ b/src/main/java/gomedic/model/activity/Title.java
@@ -24,7 +24,7 @@ public class Title extends Description {
     /**
      * @return true for text that has less than max_char
      */
-    private boolean isValidTitle(String text) {
+    public static boolean isValidTitle(String text) {
         return text.length() <= MAX_CHAR;
     }
 }

--- a/src/main/java/gomedic/model/commonfield/Id.java
+++ b/src/main/java/gomedic/model/commonfield/Id.java
@@ -40,6 +40,29 @@ public abstract class Id {
         return isValidNumber && isValidPrefix;
     }
 
+    /**
+     * Returns true id is made of 1 char followed by 3 digits.
+     *
+     * @param id String
+     * @return true if valid, else false.
+     */
+    public static boolean isValidIdFormat(String id) {
+        boolean isValidNumber = isNumeric(id.substring(1)) && id.substring(1).length() == 3;
+        char prefix = id.charAt(0);
+        boolean isValidPrefix = ('a' <= prefix && prefix <= 'z') || ('A' <= prefix && prefix <= 'Z');
+
+        return isValidNumber && isValidPrefix;
+    }
+
+    private static boolean isNumeric(String string) {
+        try {
+            Integer.parseInt(string);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     @Override
     public int hashCode() {
         return value.hashCode();

--- a/src/main/java/gomedic/model/commonfield/Id.java
+++ b/src/main/java/gomedic/model/commonfield/Id.java
@@ -41,7 +41,7 @@ public abstract class Id {
     }
 
     /**
-     * Returns true id is made of 1 char followed by 3 digits.
+     * Returns true id is made of 1 upper case alphabet followed by 3 digits.
      *
      * @param id String
      * @return true if valid, else false.
@@ -49,7 +49,7 @@ public abstract class Id {
     public static boolean isValidIdFormat(String id) {
         boolean isValidNumber = isNumeric(id.substring(1)) && id.substring(1).length() == 3;
         char prefix = id.charAt(0);
-        boolean isValidPrefix = ('a' <= prefix && prefix <= 'z') || ('A' <= prefix && prefix <= 'Z');
+        boolean isValidPrefix =  'A' <= prefix && prefix <= 'Z';
 
         return isValidNumber && isValidPrefix;
     }

--- a/src/main/java/gomedic/model/commonfield/Id.java
+++ b/src/main/java/gomedic/model/commonfield/Id.java
@@ -49,7 +49,7 @@ public abstract class Id {
     public static boolean isValidIdFormat(String id) {
         boolean isValidNumber = isNumeric(id.substring(1)) && id.substring(1).length() == 3;
         char prefix = id.charAt(0);
-        boolean isValidPrefix =  'A' <= prefix && prefix <= 'Z';
+        boolean isValidPrefix = 'A' <= prefix && prefix <= 'Z';
 
         return isValidNumber && isValidPrefix;
     }

--- a/src/main/java/gomedic/storage/AddressBookStorage.java
+++ b/src/main/java/gomedic/storage/AddressBookStorage.java
@@ -16,7 +16,7 @@ public interface AddressBookStorage {
     /**
      * Returns the file path of the data file.
      */
-    Path getAddressBookPersonsFilePath();
+    Path getAddressBookDataFilePath();
 
     /**
      * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
@@ -28,7 +28,7 @@ public interface AddressBookStorage {
     Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException;
 
     /**
-     * @see #getAddressBookPersonsFilePath()
+     * @see #getAddressBookDataFilePath()
      */
     Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException, IOException;
 

--- a/src/main/java/gomedic/storage/JsonAdaptedActivity.java
+++ b/src/main/java/gomedic/storage/JsonAdaptedActivity.java
@@ -1,0 +1,95 @@
+package gomedic.storage;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import gomedic.commons.exceptions.IllegalValueException;
+import gomedic.model.activity.Activity;
+import gomedic.model.activity.ActivityId;
+import gomedic.model.activity.Description;
+import gomedic.model.activity.Title;
+import gomedic.model.commonfield.Time;
+
+public class JsonAdaptedActivity {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Activity's %s field is missing!";
+
+    private final String id;
+    private final String title;
+    private final String description;
+    private final String startTime;
+    private final String endTime;
+
+    /**
+     * Constructs a {@code JsonAdaptedActivity} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedActivity(@JsonProperty("id") String id,
+                               @JsonProperty("title") String title,
+                               @JsonProperty("description") String description,
+                               @JsonProperty("startTime") String startTime,
+                               @JsonProperty("endTime") String endTime) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    /**
+     * Converts a given {@code Activity} into this class for Jackson use.
+     */
+    public JsonAdaptedActivity(Activity source) {
+        id = source.getActivityId().toString();
+        title = source.getTitle().toString();
+        description = source.getDescription().toString();
+        startTime = source.getStartTime().toString();
+        endTime = source.getEndTime().toString();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted person object into the model's {@code Activity} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public Activity toModelType() throws IllegalValueException {
+        if (id == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, ActivityId.class.getSimpleName()));
+        }
+        if (!ActivityId.isValidActivityId(id)) {
+            throw new IllegalValueException(ActivityId.MESSAGE_CONSTRAINTS);
+        }
+
+        final ActivityId modelId = new ActivityId(id);
+
+        if (title == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
+        }
+        if (!Title.isValidTitle(title)) {
+            throw new IllegalValueException(Title.MESSAGE_CONSTRAINTS);
+        }
+
+        final Title modelTitle = new Title(title);
+
+        if (description == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName()));
+        }
+        if (!Description.isValidDescription(title)) {
+            throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
+        }
+
+        final Description modelDescription = new Description(description);
+
+        // should check for end and start time
+        // for now, lets use some dummy stuff
+        // TODO : use the real date time parser
+
+        Time modelStartTime = new Time(LocalDateTime.now());
+        Time modelEndTime = new Time(LocalDateTime.now().plusHours(1));
+
+        return new Activity(modelId, modelStartTime, modelEndTime, modelTitle, modelDescription);
+    }
+
+
+}

--- a/src/main/java/gomedic/storage/JsonAdaptedActivity.java
+++ b/src/main/java/gomedic/storage/JsonAdaptedActivity.java
@@ -55,7 +55,8 @@ public class JsonAdaptedActivity {
      */
     public Activity toModelType() throws IllegalValueException {
         if (id == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, ActivityId.class.getSimpleName()));
+            throw new IllegalValueException(String.format(
+                    MISSING_FIELD_MESSAGE_FORMAT, ActivityId.class.getSimpleName()));
         }
         if (!ActivityId.isValidActivityId(id)) {
             throw new IllegalValueException(ActivityId.MESSAGE_CONSTRAINTS);
@@ -64,7 +65,8 @@ public class JsonAdaptedActivity {
         final ActivityId modelId = new ActivityId(id);
 
         if (title == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
+            throw new IllegalValueException(String.format(
+                    MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
         }
         if (!Title.isValidTitle(title)) {
             throw new IllegalValueException(Title.MESSAGE_CONSTRAINTS);
@@ -73,7 +75,8 @@ public class JsonAdaptedActivity {
         final Title modelTitle = new Title(title);
 
         if (description == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName()));
+            throw new IllegalValueException(String.format(
+                    MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName()));
         }
         if (!Description.isValidDescription(title)) {
             throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
@@ -90,6 +93,4 @@ public class JsonAdaptedActivity {
 
         return new Activity(modelId, modelStartTime, modelEndTime, modelTitle, modelDescription);
     }
-
-
 }

--- a/src/main/java/gomedic/storage/JsonAdaptedActivity.java
+++ b/src/main/java/gomedic/storage/JsonAdaptedActivity.java
@@ -88,8 +88,10 @@ public class JsonAdaptedActivity {
         // for now, lets use some dummy stuff
         // TODO : use the real date time parser
 
-        Time modelStartTime = new Time(LocalDateTime.now());
-        Time modelEndTime = new Time(LocalDateTime.now().plusHours(1));
+        LocalDateTime stub = LocalDateTime.now().plusDays((int) (Math.random() * 10000));
+
+        Time modelStartTime = new Time(stub);
+        Time modelEndTime = new Time(stub.plusHours(1));
 
         return new Activity(modelId, modelStartTime, modelEndTime, modelTitle, modelDescription);
     }

--- a/src/main/java/gomedic/storage/JsonAddressBookStorage.java
+++ b/src/main/java/gomedic/storage/JsonAddressBookStorage.java
@@ -47,7 +47,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
 
         Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
                 filePath, JsonSerializableAddressBook.class);
-        if (!jsonAddressBook.isPresent()) {
+        if (jsonAddressBook.isEmpty()) {
             return Optional.empty();
         }
 

--- a/src/main/java/gomedic/storage/JsonAddressBookStorage.java
+++ b/src/main/java/gomedic/storage/JsonAddressBookStorage.java
@@ -21,19 +21,19 @@ public class JsonAddressBookStorage implements AddressBookStorage {
 
     private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
 
-    private final Path filePath;
+    private final Path personFilePath;
 
-    public JsonAddressBookStorage(Path filePath) {
-        this.filePath = filePath;
+    public JsonAddressBookStorage(Path personFilePath) {
+        this.personFilePath = personFilePath;
     }
 
     public Path getAddressBookPersonsFilePath() {
-        return filePath;
+        return personFilePath;
     }
 
     @Override
     public Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException {
-        return readAddressBook(filePath);
+        return readAddressBook(personFilePath);
     }
 
     /**
@@ -61,7 +61,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
 
     @Override
     public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
-        saveAddressBook(addressBook, filePath);
+        saveAddressBook(addressBook, personFilePath);
     }
 
     /**
@@ -76,5 +76,4 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         FileUtil.createIfMissing(filePath);
         JsonUtil.saveJsonFile(new JsonSerializableAddressBook(addressBook), filePath);
     }
-
 }

--- a/src/main/java/gomedic/storage/JsonAddressBookStorage.java
+++ b/src/main/java/gomedic/storage/JsonAddressBookStorage.java
@@ -21,19 +21,19 @@ public class JsonAddressBookStorage implements AddressBookStorage {
 
     private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
 
-    private final Path personFilePath;
+    private final Path dataRootFilePath;
 
-    public JsonAddressBookStorage(Path personFilePath) {
-        this.personFilePath = personFilePath;
+    public JsonAddressBookStorage(Path dataRootFilePath) {
+        this.dataRootFilePath = dataRootFilePath;
     }
 
-    public Path getAddressBookPersonsFilePath() {
-        return personFilePath;
+    public Path getAddressBookDataFilePath() {
+        return dataRootFilePath;
     }
 
     @Override
     public Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException {
-        return readAddressBook(personFilePath);
+        return readAddressBook(dataRootFilePath);
     }
 
     /**
@@ -61,7 +61,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
 
     @Override
     public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
-        saveAddressBook(addressBook, personFilePath);
+        saveAddressBook(addressBook, dataRootFilePath);
     }
 
     /**

--- a/src/main/java/gomedic/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/gomedic/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import gomedic.commons.exceptions.IllegalValueException;
 import gomedic.model.AddressBook;
 import gomedic.model.ReadOnlyAddressBook;
+import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
 
 /**
@@ -20,15 +21,23 @@ import gomedic.model.person.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_ACTIVITY = "Activities list contains duplicate person(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedActivity> activities = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableAddressBook} with the given persons.
+     * Constructs a {@code JsonSerializableAddressBook} with the given persons and activities.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
-        this.persons.addAll(persons);
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                       @JsonProperty("activities") List<JsonAdaptedActivity> activities) {
+        if (persons != null) {
+            this.persons.addAll(persons);
+        }
+        if (activities != null) {
+            this.activities.addAll(activities);
+        }
     }
 
     /**
@@ -38,6 +47,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        activities.addAll(source.getActivityList().stream().map(JsonAdaptedActivity::new).collect(Collectors.toList()));
     }
 
     /**
@@ -54,7 +64,16 @@ class JsonSerializableAddressBook {
             }
             addressBook.addPerson(person);
         }
+
+        for (JsonAdaptedActivity jsonAdaptedActivity : activities) {
+            Activity activity = jsonAdaptedActivity.toModelType();
+
+            if (addressBook.hasActivity(activity)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_ACTIVITY);
+            }
+            addressBook.addActivity(activity);
+        }
+
         return addressBook;
     }
-
 }

--- a/src/main/java/gomedic/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/gomedic/storage/JsonSerializableAddressBook.java
@@ -32,12 +32,8 @@ class JsonSerializableAddressBook {
     @JsonCreator
     public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
                                        @JsonProperty("activities") List<JsonAdaptedActivity> activities) {
-        if (persons != null) {
-            this.persons.addAll(persons);
-        }
-        if (activities != null) {
-            this.activities.addAll(activities);
-        }
+        this.persons.addAll(persons);
+        this.activities.addAll(activities);
     }
 
     /**

--- a/src/main/java/gomedic/storage/Storage.java
+++ b/src/main/java/gomedic/storage/Storage.java
@@ -21,7 +21,7 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
 
     @Override
-    Path getAddressBookPersonsFilePath();
+    Path getAddressBookDataFilePath();
 
     @Override
     Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException;

--- a/src/main/java/gomedic/storage/StorageManager.java
+++ b/src/main/java/gomedic/storage/StorageManager.java
@@ -50,13 +50,13 @@ public class StorageManager implements Storage {
     // ================ AddressBook methods ==============================
 
     @Override
-    public Path getAddressBookPersonsFilePath() {
-        return addressBookStorage.getAddressBookPersonsFilePath();
+    public Path getAddressBookDataFilePath() {
+        return addressBookStorage.getAddressBookDataFilePath();
     }
 
     @Override
     public Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException {
-        return readAddressBook(addressBookStorage.getAddressBookPersonsFilePath());
+        return readAddressBook(addressBookStorage.getAddressBookDataFilePath());
     }
 
     @Override
@@ -67,7 +67,7 @@ public class StorageManager implements Storage {
 
     @Override
     public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
-        saveAddressBook(addressBook, addressBookStorage.getAddressBookPersonsFilePath());
+        saveAddressBook(addressBook, addressBookStorage.getAddressBookDataFilePath());
     }
 
     @Override

--- a/src/main/java/gomedic/ui/MainWindow.java
+++ b/src/main/java/gomedic/ui/MainWindow.java
@@ -115,7 +115,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookRootFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -1,13 +1,17 @@
 {
-  "persons": [ {
-    "name": "Valid Person",
-    "phone": "9482424",
-    "email": "hans@example.com",
-    "address": "4th street"
-  }, {
-    "name": "Person With Invalid Phone Field",
-    "phone": "948asdf2424",
-    "email": "hans@example.com",
-    "address": "4th street"
-  } ]
+  "persons": [
+    {
+      "name": "Valid Person",
+      "phone": "9482424",
+      "email": "hans@example.com",
+      "address": "4th street"
+    },
+    {
+      "name": "Person With Invalid Phone Field",
+      "phone": "948asdf2424",
+      "email": "hans@example.com",
+      "address": "4th street"
+    }
+  ],
+  "activities": []
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -1,8 +1,11 @@
 {
-  "persons": [ {
-    "name": "Person with invalid name field: Ha!ns Mu@ster",
-    "phone": "9482424",
-    "email": "hans@example.com",
-    "address": "4th street"
-  } ]
+  "persons": [
+    {
+      "name": "Person with invalid name field: Ha!ns Mu@ster",
+      "phone": "9482424",
+      "email": "hans@example.com",
+      "address": "4th street"
+    }
+  ],
+  "activities": []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/conflictingActivitiesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/conflictingActivitiesAddressBook.json
@@ -1,0 +1,25 @@
+{
+  "persons": [ {
+    "name": "Alice Pauline",
+    "phone": "94351253",
+    "email": "pauline@example.com",
+    "address": "4th street"
+  } ],
+  "activities": [
+    {
+      "id": "A001",
+      "title": "testing activity",
+      "description": "meeting someone at Jurong east",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    },
+    {
+      "id": "A002",
+      "title": "another activity",
+      "description": "meeting someone at Jurong east",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    }
+  ]
+}
+// TODO : Update the data

--- a/src/test/data/JsonSerializableAddressBookTest/conflictingActivitiesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/conflictingActivitiesAddressBook.json
@@ -1,10 +1,5 @@
 {
-  "persons": [ {
-    "name": "Alice Pauline",
-    "phone": "94351253",
-    "email": "pauline@example.com",
-    "address": "4th street"
-  } ],
+  "persons": [],
   "activities": [
     {
       "id": "A001",

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateActivitiesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateActivitiesAddressBook.json
@@ -1,0 +1,25 @@
+{
+  "persons": [ {
+    "name": "Alice Pauline",
+    "phone": "94351253",
+    "email": "pauline@example.com",
+    "address": "4th street"
+  } ],
+  "activities": [
+    {
+      "id": "A001",
+      "title": "testing activity",
+      "description": "meeting someone at Jurong east",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    },
+    {
+      "id": "A001",
+      "title": "another activity",
+      "description": "meeting someone at Jurong east",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    }
+  ]
+}
+// TODO : Update the data

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateActivitiesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateActivitiesAddressBook.json
@@ -1,10 +1,5 @@
 {
-  "persons": [ {
-    "name": "Alice Pauline",
-    "phone": "94351253",
-    "email": "pauline@example.com",
-    "address": "4th street"
-  } ],
+  "persons": [],
   "activities": [
     {
       "id": "A001",

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -10,5 +10,28 @@
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street"
-  } ]
+  } ],
+  "activities": [
+    {
+      "id": "A001",
+      "title": "Meeting me",
+      "description": "today at somewhere",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    },
+    {
+      "id": "A003",
+      "title": "Paper Review",
+      "description": "someone is attending this",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    },
+    {
+      "id": "A004",
+      "title": "playing games",
+      "description": "at someone house",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    }
+  ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidActivityAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidActivityAddressBook.json
@@ -1,0 +1,26 @@
+{
+  "persons": [
+    {
+      "name": "Hans Muster",
+      "phone": "9482424",
+      "email": "invalid@email!3e",
+      "address": "4th street"
+    }
+  ],
+  "activities": [
+    {
+      "id": "A001",
+      "title": "Very very long title that would exceed 60 character for sure, again Very very long title that would exceed 60 character for sure",
+      "description": "meeting someone at Jurong east",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    },
+    {
+      "id": "B002",
+      "title": "Invalid id, supposed to start with A",
+      "description": "meeting someone at Jurong east",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    }
+  ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -4,5 +4,14 @@
     "phone": "9482424",
     "email": "invalid@email!3e",
     "address": "4th street"
-  } ]
+  } ],
+  "activities": [
+    {
+      "id": "A001",
+      "title": "another activity",
+      "description": "meeting someone at Jurong east",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    }
+  ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
@@ -42,5 +42,28 @@
     "email" : "anna@example.com",
     "address" : "4th street",
     "tagged" : [ ]
-  } ]
+  } ],
+  "activities": [
+    {
+      "id": "A001",
+      "title": "Meeting me",
+      "description": "today at somewhere",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    },
+    {
+      "id": "A003",
+      "title": "Paper Review",
+      "description": "someone is attending this",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    },
+    {
+      "id": "A004",
+      "title": "playing games",
+      "description": "at someone house",
+      "startTime": "XXX",
+      "endTime": "XXX"
+    }
+  ]
 }

--- a/src/test/java/gomedic/logic/commands/AddCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/AddCommandTest.java
@@ -3,12 +3,11 @@ package gomedic.logic.commands;
 import static gomedic.testutil.Assert.assertThrows;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ public class AddCommandTest {
         CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
 
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validPerson), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
+        assertEquals(List.of(validPerson), modelStub.personsAdded);
     }
 
     @Test
@@ -58,26 +57,26 @@ public class AddCommandTest {
         AddCommand addBobCommand = new AddCommand(bob);
 
         // same object -> returns true
-        assertTrue(addAliceCommand.equals(addAliceCommand));
+        assertEquals(addAliceCommand, addAliceCommand);
 
         // same values -> returns true
         AddCommand addAliceCommandCopy = new AddCommand(alice);
-        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
+        assertEquals(addAliceCommand, addAliceCommandCopy);
 
         // different types -> returns false
-        assertFalse(addAliceCommand.equals(1));
+        assertNotEquals(1, addAliceCommand);
 
         // null -> returns false
-        assertFalse(addAliceCommand.equals(null));
+        assertNotEquals(null, addAliceCommand);
 
         // different person -> returns false
-        assertFalse(addAliceCommand.equals(addBobCommand));
+        assertNotEquals(addAliceCommand, addBobCommand);
     }
 
     /**
-     * A default model stub that have all of the methods failing.
+     * A default model stub that have all the methods failing.
      */
-    private class ModelStub implements Model {
+    private static class ModelStub implements Model {
         @Override
         public ReadOnlyUserPrefs getUserPrefs() {
             throw new AssertionError("This method should not be called.");
@@ -105,16 +104,6 @@ public class AddCommandTest {
 
         @Override
         public void setAddressBookDataRootFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookPersonsFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookActivitiesFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -162,7 +151,7 @@ public class AddCommandTest {
     /**
      * A Model stub that contains a single person.
      */
-    private class ModelStubWithPerson extends ModelStub {
+    private static class ModelStubWithPerson extends ModelStub {
         private final Person person;
 
         ModelStubWithPerson(Person person) {
@@ -180,7 +169,7 @@ public class AddCommandTest {
     /**
      * A Model stub that always accept the person being added.
      */
-    private class ModelStubAcceptingPersonAdded extends ModelStub {
+    private static class ModelStubAcceptingPersonAdded extends ModelStub {
         final ArrayList<Person> personsAdded = new ArrayList<>();
 
         @Override

--- a/src/test/java/gomedic/logic/commands/AddCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/AddCommandTest.java
@@ -99,12 +99,22 @@ public class AddCommandTest {
         }
 
         @Override
-        public Path getAddressBookPersonFilePath() {
+        public Path getAddressBookDataRootFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setAddressBookPersonFilePath(Path addressBookFilePath) {
+        public void setAddressBookDataRootFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookPersonsFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookActivitiesFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/gomedic/model/ModelManagerTest.java
+++ b/src/test/java/gomedic/model/ModelManagerTest.java
@@ -36,14 +36,14 @@ public class ModelManagerTest {
     @Test
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookPersonFilePath(Paths.get("address/book/file/path"));
+        userPrefs.setAddressBookDataFileRootPath(Paths.get("address/book/file/path"));
         userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
         // Modifying userPrefs should not modify modelManager's userPrefs
         UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
-        userPrefs.setAddressBookPersonFilePath(Paths.get("new/address/book/file/path"));
+        userPrefs.setAddressBookDataFileRootPath(Paths.get("new/address/book/file/path"));
         assertEquals(oldUserPrefs, modelManager.getUserPrefs());
     }
 
@@ -61,14 +61,14 @@ public class ModelManagerTest {
 
     @Test
     public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> modelManager.setAddressBookPersonFilePath(null));
+        Assert.assertThrows(NullPointerException.class, () -> modelManager.setAddressBookDataRootFilePath(null));
     }
 
     @Test
     public void setAddressBookFilePath_validPath_setsAddressBookFilePath() {
         Path path = Paths.get("address/book/file/path");
-        modelManager.setAddressBookPersonFilePath(path);
-        assertEquals(path, modelManager.getAddressBookPersonFilePath());
+        modelManager.setAddressBookDataRootFilePath(path);
+        assertEquals(path, modelManager.getAddressBookDataRootFilePath());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ModelManagerTest {
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
-        differentUserPrefs.setAddressBookPersonFilePath(Paths.get("differentFilePath"));
+        differentUserPrefs.setAddressBookDataFileRootPath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
     }
 }

--- a/src/test/java/gomedic/model/UserPrefsTest.java
+++ b/src/test/java/gomedic/model/UserPrefsTest.java
@@ -17,5 +17,4 @@ public class UserPrefsTest {
         UserPrefs userPrefs = new UserPrefs();
         Assert.assertThrows(NullPointerException.class, () -> userPrefs.setAddressBookDataFileRootPath(null));
     }
-
 }

--- a/src/test/java/gomedic/model/UserPrefsTest.java
+++ b/src/test/java/gomedic/model/UserPrefsTest.java
@@ -15,7 +15,7 @@ public class UserPrefsTest {
     @Test
     public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
         UserPrefs userPrefs = new UserPrefs();
-        Assert.assertThrows(NullPointerException.class, () -> userPrefs.setAddressBookPersonFilePath(null));
+        Assert.assertThrows(NullPointerException.class, () -> userPrefs.setAddressBookDataFileRootPath(null));
     }
 
 }

--- a/src/test/java/gomedic/model/activity/ActivityIdTest.java
+++ b/src/test/java/gomedic/model/activity/ActivityIdTest.java
@@ -13,6 +13,7 @@ public class ActivityIdTest {
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new ActivityId((Integer) null));
+        assertThrows(NullPointerException.class, () -> new ActivityId((String) null));
     }
 
     @Test

--- a/src/test/java/gomedic/model/activity/ActivityIdTest.java
+++ b/src/test/java/gomedic/model/activity/ActivityIdTest.java
@@ -12,7 +12,7 @@ import gomedic.model.commonfield.IdTest;
 public class ActivityIdTest {
     @Test
     public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new ActivityId(null));
+        assertThrows(NullPointerException.class, () -> new ActivityId((Integer) null));
     }
 
     @Test
@@ -26,9 +26,9 @@ public class ActivityIdTest {
     }
 
     @Test
-    void isValidId_validInput_testsPassed() {
+    void isValidId_validInputId_testsPassed() {
         // null activity id
-        assertThrows(NullPointerException.class, () -> new ActivityId(null));
+        assertThrows(NullPointerException.class, () -> new ActivityId((Integer) null));
 
         // invalid activity id
         assertFalse(ActivityId.isValidActivityId(new IdTest.TestId(999, 'C'))); // wrong prefix
@@ -44,5 +44,16 @@ public class ActivityIdTest {
     void equals_inputs_testsPassed() {
         assertEquals(new ActivityId(100), new ActivityId(100));
         assertEquals(new ActivityId(100), new IdTest.TestId(100, 'A'));
+    }
+
+    @Test
+    void isValidActivityId_stringInput_testsPassed() {
+        // invalid activity id
+        assertFalse(ActivityId.isValidActivityId("test")); // no integer
+        assertFalse(ActivityId.isValidActivityId("A100")); // wrong prefix
+
+        // valid activity id
+        assertTrue(ActivityId.isValidActivityId(new ActivityId(100))); // activity id
+        assertTrue(ActivityId.isValidActivityId(new IdTest.TestId(50, 'A'))); // other id with same prefix
     }
 }

--- a/src/test/java/gomedic/model/activity/ActivityIdTest.java
+++ b/src/test/java/gomedic/model/activity/ActivityIdTest.java
@@ -50,7 +50,7 @@ public class ActivityIdTest {
     void isValidActivityId_stringInput_testsPassed() {
         // invalid activity id
         assertFalse(ActivityId.isValidActivityId("test")); // no integer
-        assertFalse(ActivityId.isValidActivityId("A100")); // wrong prefix
+        assertFalse(ActivityId.isValidActivityId("B100")); // wrong prefix
 
         // valid activity id
         assertTrue(ActivityId.isValidActivityId(new ActivityId(100))); // activity id

--- a/src/test/java/gomedic/model/activity/DescriptionTest.java
+++ b/src/test/java/gomedic/model/activity/DescriptionTest.java
@@ -1,5 +1,6 @@
 package gomedic.model.activity;
 
+import static gomedic.model.activity.Description.isValidDescription;
 import static gomedic.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -52,5 +53,11 @@ class DescriptionTest {
         // upper case and lower case
         assertTrue(d.contains("TESTING", "STRINGS"));
         assertTrue(d.contains("testing", "lmao"));
+    }
+
+    @Test
+    void isValidDescription_testsPassed() {
+        assertTrue(isValidDescription("a".repeat(100)));
+        assertFalse(isValidDescription("a".repeat(1000)));
     }
 }

--- a/src/test/java/gomedic/model/activity/TitleTest.java
+++ b/src/test/java/gomedic/model/activity/TitleTest.java
@@ -1,5 +1,6 @@
 package gomedic.model.activity;
 
+import static gomedic.model.activity.Title.isValidTitle;
 import static gomedic.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -46,5 +47,11 @@ class TitleTest {
         // upper case and lower case
         assertTrue(d.contains("TESTING", "STRINGS"));
         assertTrue(d.contains("testing", "lmao"));
+    }
+
+    @Test
+    void isValidTitle_testsPassed() {
+        assertTrue(isValidTitle("a".repeat(10)));
+        assertFalse(isValidTitle("a".repeat(61)));
     }
 }

--- a/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
+++ b/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
@@ -50,10 +50,16 @@ class UniqueActivityListTest {
 
     @Test
     void containsConflicting_variousMeeting_testPassed() {
+        assertFalse(uniqueActivityList.containsConflicting(MEETING));
+
         uniqueActivityList.add(MEETING);
         assertTrue(uniqueActivityList.contains(MEETING));
         assertTrue(uniqueActivityList.containsConflicting(CONFLICTING_MEETING));
         assertFalse(uniqueActivityList.containsConflicting(PAST_ACTIVITY));
+        assertFalse(uniqueActivityList.containsConflicting(PAPER_REVIEW));
+
+        uniqueActivityList.add(PAST_ACTIVITY);
+        assertFalse(uniqueActivityList.containsConflicting(PAPER_REVIEW));
     }
 
     @Test

--- a/src/test/java/gomedic/model/commonfield/IdTest.java
+++ b/src/test/java/gomedic/model/commonfield/IdTest.java
@@ -80,11 +80,11 @@ public class IdTest {
     public void isValidIdFormat() {
         // valid Id format
         assertTrue(Id.isValidIdFormat("Z999"));
-        assertTrue(Id.isValidIdFormat("a100"));
 
         // invalid id format
         assertFalse(Id.isValidIdFormat("test"));
         assertFalse(Id.isValidIdFormat("A1"));
+        assertFalse(Id.isValidIdFormat("a100"));
     }
 
     /**

--- a/src/test/java/gomedic/model/commonfield/IdTest.java
+++ b/src/test/java/gomedic/model/commonfield/IdTest.java
@@ -76,6 +76,17 @@ public class IdTest {
         assertTrue(Id.isValidId(50, 'K')); // common case prefix and id
     }
 
+    @Test
+    public void isValidIdFormat() {
+        // valid Id format
+        assertTrue(Id.isValidIdFormat("Z999"));
+        assertTrue(Id.isValidIdFormat("a100"));
+
+        // invalid id format
+        assertFalse(Id.isValidIdFormat("test"));
+        assertFalse(Id.isValidIdFormat("A1"));
+    }
+
     /**
      * Mock id class to be tested.
      */

--- a/src/test/java/gomedic/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/gomedic/storage/JsonAddressBookStorageTest.java
@@ -58,6 +58,7 @@ public class JsonAddressBookStorageTest {
                 DataConversionException.class, () -> readAddressBook("invalidAndValidPersonAddressBook.json"));
     }
 
+    // TODO: add more tests for the activities
     @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         Path filePath = testFolder.resolve("TempAddressBook.json");

--- a/src/test/java/gomedic/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/gomedic/storage/JsonSerializableAddressBookTest.java
@@ -18,6 +18,7 @@ public class JsonSerializableAddressBookTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonSerializableAddressBookTest");
     private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalAddressBook.json");
     private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.json");
+    private static final Path INVALID_ACTIVITY_FILE = TEST_DATA_FOLDER.resolve("invalidActivityAddressBook.json");
     private static final Path DUPLICATE_PERSON_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonAddressBook.json");
     private static final Path CONFLICTING_ACTIVITY_FILE = TEST_DATA_FOLDER
             .resolve("conflictingActivitiesAddressBook.json");
@@ -44,6 +45,14 @@ public class JsonSerializableAddressBookTest {
     @Test
     public void toModelType_duplicateActivity_throwsIllegalValueException() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_ACTIVITY_FILE,
+                JsonSerializableAddressBook.class).get();
+
+        Assert.assertThrows(IllegalValueException.class, dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidActivity_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_ACTIVITY_FILE,
                 JsonSerializableAddressBook.class).get();
 
         Assert.assertThrows(IllegalValueException.class, dataFromFile::toModelType);

--- a/src/test/java/gomedic/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/gomedic/storage/JsonSerializableAddressBookTest.java
@@ -16,9 +16,12 @@ import gomedic.testutil.TypicalPersons;
 public class JsonSerializableAddressBookTest {
 
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonSerializableAddressBookTest");
-    private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalPersonsAddressBook.json");
+    private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalAddressBook.json");
     private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.json");
     private static final Path DUPLICATE_PERSON_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonAddressBook.json");
+    private static final Path CONFLICTING_ACTIVITY_FILE = TEST_DATA_FOLDER
+            .resolve("conflictingActivitiesAddressBook.json");
+    private static final Path DUPLICATE_ACTIVITY_FILE = TEST_DATA_FOLDER.resolve("duplicateActivitiesAddressBook.json");
 
     @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
@@ -27,6 +30,23 @@ public class JsonSerializableAddressBookTest {
         AddressBook addressBookFromFile = dataFromFile.toModelType();
         AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
+    }
+
+    // TODO : Uncomment this once the data is already correct
+    //    @Test
+    //    public void toModelType_conflictingActivity_throwsConflictingActivityException() throws Exception {
+    //        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(CONFLICTING_ACTIVITY_FILE,
+    //                JsonSerializableAddressBook.class).get();
+    //
+    //        Assert.assertThrows(ConflictingActivityException.class, dataFromFile::toModelType);
+    //    }
+
+    @Test
+    public void toModelType_duplicateActivity_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_ACTIVITY_FILE,
+                JsonSerializableAddressBook.class).get();
+
+        Assert.assertThrows(IllegalValueException.class, dataFromFile::toModelType);
     }
 
     @Test

--- a/src/test/java/gomedic/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/gomedic/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setAddressBookPersonFilePath(Paths.get("data", "persons.json"));
+        userPrefs.setAddressBookDataFileRootPath(Paths.get("data", "persons.json"));
         return userPrefs;
     }
 

--- a/src/test/java/gomedic/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/gomedic/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setAddressBookDataFileRootPath(Paths.get("data", "persons.json"));
+        userPrefs.setAddressBookDataFileRootPath(Paths.get("data", "addressbook.json"));
         return userPrefs;
     }
 

--- a/src/test/java/gomedic/storage/StorageManagerTest.java
+++ b/src/test/java/gomedic/storage/StorageManagerTest.java
@@ -62,7 +62,7 @@ public class StorageManagerTest {
 
     @Test
     public void getAddressBookFilePath() {
-        assertNotNull(storageManager.getAddressBookPersonsFilePath());
+        assertNotNull(storageManager.getAddressBookDataFilePath());
     }
 
 }

--- a/src/test/java/gomedic/testutil/TypicalActivities.java
+++ b/src/test/java/gomedic/testutil/TypicalActivities.java
@@ -9,6 +9,7 @@ import gomedic.model.activity.Activity;
 import gomedic.testutil.modelbuilder.ActivityBuilder;
 
 public class TypicalActivities {
+    // TODO : use the parser to convert string into local date time
     public static final Activity MEETING = new ActivityBuilder().withTitle("Meeting me")
             .withDescription("today at somewhere")
             .withStartTime(LocalDateTime.now())

--- a/src/test/java/gomedic/testutil/TypicalPersons.java
+++ b/src/test/java/gomedic/testutil/TypicalPersons.java
@@ -1,11 +1,14 @@
 package gomedic.testutil;
 
+import static gomedic.testutil.TypicalActivities.getTypicalActivities;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import gomedic.logic.commands.CommandTestUtil;
 import gomedic.model.AddressBook;
+import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
 import gomedic.testutil.modelbuilder.PersonBuilder;
 
@@ -63,6 +66,10 @@ public class TypicalPersons {
         AddressBook ab = new AddressBook();
         for (Person person : getTypicalPersons()) {
             ab.addPerson(person);
+        }
+
+        for (Activity activity : getTypicalActivities()) {
+            ab.addActivity(activity);
         }
 
         return ab;


### PR DESCRIPTION
### Summary

* All the data is eventually stored in addressbook.json (just in different json attributes)
* Add the tests to check various valid and invalid activities files 

### Detail

* The activities data and JsonActivity is still not correct because the time parser is not there yet 
* Just integrated the storage
* Reasoning why the data is not separated: there are too many test cases already written and its just fixed to addressbook.json, hence don't think it's worth it to rewrite all the test cases (I surrender) 
* Add new test for id and description because all string should be able to be converted to the field (meaning all constructors should be able to get string and parse it on their owns from the JSON file)

### Pictures / Gif
**At the addressbook sample data inside `src/test`**
![image](https://user-images.githubusercontent.com/51783522/136213252-6a974ff7-598a-4341-b1b7-7af8f4ac84a9.png)

### Checks

- [x] Add Reviewer
- [x] Pass CI
