### PR TITLE
Lauwsj/display activities

### DIFF
--- a/src/main/java/gomedic/logic/Logic.java
+++ b/src/main/java/gomedic/logic/Logic.java
@@ -10,6 +10,7 @@ import gomedic.model.Model;
 import gomedic.model.ReadOnlyAddressBook;
 import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 
 /**
@@ -36,7 +37,7 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
 
-    /** Returns an unmodifiable view of the filtered list of activities */
+    /** Returns an unmodifiable view of the filtered list of activities sorted by id */
     ObservableList<Activity> getFilteredActivityList();
 
     /**
@@ -53,4 +54,11 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the integer showing current item being shown.
+     * 0 -> activity
+     * 1 -> person
+     */
+    ObservableValue<Integer> getModelBeingShown();
 }

--- a/src/main/java/gomedic/logic/LogicManager.java
+++ b/src/main/java/gomedic/logic/LogicManager.java
@@ -16,6 +16,7 @@ import gomedic.model.ReadOnlyAddressBook;
 import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
 import gomedic.storage.Storage;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 
 /**
@@ -23,8 +24,9 @@ import javafx.collections.ObservableList;
  */
 public class LogicManager implements Logic {
     public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
-    private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
+
+    private final Logger logger = LogsCenter.getLogger(LogicManager.class);
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
@@ -83,5 +85,10 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public ObservableValue<Integer> getModelBeingShown() {
+        return model.getModelBeingShown();
     }
 }

--- a/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
@@ -9,19 +9,19 @@ import gomedic.model.Model;
 import gomedic.model.ModelItem;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all activities in the address book to the user.
  */
-public class ListPersonCommand extends Command {
+public class ListActivityCommand extends Command {
 
-    public static final String COMMAND_WORD = "list t/person";
+    public static final String COMMAND_WORD = "list t/activity";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all activities sorted by id";
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setModelBeingShown(ModelItem.PERSON);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_ITEMS);
+        model.setModelBeingShown(ModelItem.ACTIVITY);
+        model.updateFilteredActivitiesList(PREDICATE_SHOW_ALL_ITEMS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/gomedic/logic/commands/listcommand/ListPersonCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListPersonCommand.java
@@ -1,16 +1,18 @@
-package gomedic.logic.commands;
+package gomedic.logic.commands.listcommand;
 
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
 
+import gomedic.logic.commands.Command;
+import gomedic.logic.commands.CommandResult;
 import gomedic.model.Model;
 
 /**
  * Lists all persons in the address book to the user.
  */
-public class ListCommand extends Command {
+public class ListPersonCommand extends Command {
 
-    public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_WORD = "list t/person";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 

--- a/src/main/java/gomedic/logic/parser/AddressBookParser.java
+++ b/src/main/java/gomedic/logic/parser/AddressBookParser.java
@@ -11,9 +11,10 @@ import gomedic.logic.commands.EditCommand;
 import gomedic.logic.commands.ExitCommand;
 import gomedic.logic.commands.FindCommand;
 import gomedic.logic.commands.HelpCommand;
-import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.commands.addcommand.AddActivityCommand;
 import gomedic.logic.commands.addcommand.AddPersonCommand;
+import gomedic.logic.commands.listcommand.ListActivityCommand;
+import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.parser.addcommandparser.AddActivityCommandParser;
 import gomedic.logic.parser.addcommandparser.AddPersonCommandParser;
 import gomedic.logic.parser.exceptions.ParseException;
@@ -77,6 +78,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case ListActivityCommand.COMMAND_WORD:
+            return new ListActivityCommand();
 
         case ListPersonCommand.COMMAND_WORD:
             return new ListPersonCommand();

--- a/src/main/java/gomedic/logic/parser/AddressBookParser.java
+++ b/src/main/java/gomedic/logic/parser/AddressBookParser.java
@@ -11,7 +11,7 @@ import gomedic.logic.commands.EditCommand;
 import gomedic.logic.commands.ExitCommand;
 import gomedic.logic.commands.FindCommand;
 import gomedic.logic.commands.HelpCommand;
-import gomedic.logic.commands.ListCommand;
+import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.commands.addcommand.AddActivityCommand;
 import gomedic.logic.commands.addcommand.AddPersonCommand;
 import gomedic.logic.parser.addcommandparser.AddActivityCommandParser;
@@ -78,8 +78,8 @@ public class AddressBookParser {
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+        case ListPersonCommand.COMMAND_WORD:
+            return new ListPersonCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/gomedic/model/AddressBook.java
+++ b/src/main/java/gomedic/model/AddressBook.java
@@ -57,7 +57,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
-        setActivities(newData.getActivityList());
+        setActivities(newData.getActivityListSortedById());
         setDoctors(newData.getDoctorList());
     }
 
@@ -207,7 +207,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public String toString() {
         return persons.asUnmodifiableObservableList().size() + " persons; "
-                + activities.asUnmodifiableObservableList().size() + " activities;"
+                + activities.asUnmodifiableSortedByIdObservableList().size() + " activities;"
                 + doctors.asUnmodifiableObservableList().size() + " doctors";
         // TODO: refine later
     }
@@ -223,13 +223,13 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public ObservableList<Activity> getActivityList() {
-        return activities.asUnmodifiableObservableList();
+    public ObservableList<Activity> getActivityListSortedById() {
+        return activities.asUnmodifiableSortedByIdObservableList();
     }
 
     @Override
     public ObservableList<Activity> getActivityListSortedStartTime() {
-        return activities.asUnmodifiableSortedList();
+        return activities.asUnmodifiableSortedByStartTimeList();
     }
 
     @Override

--- a/src/main/java/gomedic/model/Model.java
+++ b/src/main/java/gomedic/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import gomedic.commons.core.GuiSettings;
 import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 
 /**
@@ -111,4 +112,23 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<? super Person> predicate);
+
+    /**
+     * Updates the filter of the filtered activities list to filter by the given {@code predicate}.
+     *
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredActivitiesList(Predicate<? super Activity> predicate);
+
+    /**
+     * Returns the integer showing current item being shown.
+     * 0 -> activity
+     * 1 -> person
+     */
+    ObservableValue<Integer> getModelBeingShown();
+
+    /**
+     * Sets the model being shown.
+     */
+    void setModelBeingShown(ModelItem modelItem);
 }

--- a/src/main/java/gomedic/model/ModelItem.java
+++ b/src/main/java/gomedic/model/ModelItem.java
@@ -1,0 +1,6 @@
+package gomedic.model;
+
+public enum ModelItem {
+    ACTIVITY,
+    PERSON
+}

--- a/src/main/java/gomedic/model/ModelManager.java
+++ b/src/main/java/gomedic/model/ModelManager.java
@@ -11,6 +11,9 @@ import gomedic.commons.core.LogsCenter;
 import gomedic.commons.util.CollectionUtil;
 import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 
@@ -19,11 +22,14 @@ import javafx.collections.transformation.FilteredList;
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
-
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Activity> filteredActivities;
+    // used the ordinal value 0 -> Activity, 1 -> Person for simplicity instead of implementing new class.
+    private final ObjectProperty<Integer> internalModelItemBeingShown =
+            new SimpleIntegerProperty(ModelItem.ACTIVITY.ordinal()).asObject();
+    private final ObservableValue<Integer> modelItemBeingShown = internalModelItemBeingShown; // immutable
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
@@ -41,15 +47,15 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        filteredActivities = new FilteredList<>(this.addressBook.getActivityList());
+        filteredActivities = new FilteredList<>(this.addressBook.getActivityListSortedById());
     }
-
-    //=========== UserPrefs ==================================================================================
 
     @Override
     public ReadOnlyUserPrefs getUserPrefs() {
         return userPrefs;
     }
+
+    //=========== UserPrefs ==================================================================================
 
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -79,12 +85,12 @@ public class ModelManager implements Model {
         userPrefs.setAddressBookDataFileRootPath(addressBookDataRootFilePath);
     }
 
-    //=========== AddressBook ================================================================================
-
     @Override
     public ReadOnlyAddressBook getAddressBook() {
         return addressBook;
     }
+
+    //=========== AddressBook ================================================================================
 
     @Override
     public void setAddressBook(ReadOnlyAddressBook addressBook) {
@@ -116,6 +122,23 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void updateFilteredActivitiesList(Predicate<? super Activity> predicate) {
+        requireNonNull(predicate);
+        filteredActivities.setPredicate(predicate);
+    }
+
+    @Override
+    public ObservableValue<Integer> getModelBeingShown() {
+        return modelItemBeingShown;
+    }
+
+    @Override
+    public void setModelBeingShown(ModelItem modelItem) {
+        requireNonNull(modelItem);
+        internalModelItemBeingShown.setValue(modelItem.ordinal());
+    }
+
+    @Override
     public void addActivity(Activity activity) {
         requireNonNull(activity);
         addressBook.addActivity(activity);
@@ -144,14 +167,14 @@ public class ModelManager implements Model {
         return addressBook.hasConflictingActivity(activity);
     }
 
-    //=========== Filtered Person List Accessors =============================================================
-
     @Override
     public void setPerson(Person target, Person editedPerson) {
         CollectionUtil.requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
     }
+
+    //=========== Filtered Person List Accessors =============================================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
@@ -186,5 +209,4 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(other.filteredPersons)
                 && filteredActivities.equals(other.filteredActivities);
     }
-
 }

--- a/src/main/java/gomedic/model/ReadOnlyAddressBook.java
+++ b/src/main/java/gomedic/model/ReadOnlyAddressBook.java
@@ -26,7 +26,7 @@ public interface ReadOnlyAddressBook {
      * Returns an unmodifiable view of the activity list.
      * Guarantee: This list will not contain any conflicting and duplicate activity.
      */
-    ObservableList<Activity> getActivityList();
+    ObservableList<Activity> getActivityListSortedById();
 
     /**
      * Returns a sorted list by start time.

--- a/src/main/java/gomedic/model/activity/UniqueActivityList.java
+++ b/src/main/java/gomedic/model/activity/UniqueActivityList.java
@@ -23,7 +23,7 @@ import javafx.collections.ObservableList;
  * Supports  a minimal set of list operations.
  */
 public class UniqueActivityList implements Iterable<Activity> {
-    private final int MAX_CAPACITY = 999;
+    public static final int MAX_CAPACITY = 999;
     private final ObservableList<Activity> internalList = FXCollections.observableArrayList();
     private final ObservableList<Activity> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
@@ -179,15 +179,20 @@ public class UniqueActivityList implements Iterable<Activity> {
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
-    public ObservableList<Activity> asUnmodifiableObservableList() {
-        return internalUnmodifiableList;
+    public ObservableList<Activity> asUnmodifiableSortedByIdObservableList() {
+        return internalUnmodifiableList
+                .sorted((activity, otherAct) ->
+                        activity.getActivityId() == otherAct.getActivityId()
+                                ? 0
+                                : activity.getActivityId().getIdNumber()
+                                < otherAct.getActivityId().getIdNumber() ? -1 : 1);
     }
 
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      * Returned list is sorted by starting the start time.
      */
-    public ObservableList<Activity> asUnmodifiableSortedList() {
+    public ObservableList<Activity> asUnmodifiableSortedByStartTimeList() {
         return internalUnmodifiableList
                 .sorted((activity, otherAct) ->
                         activity.getStartTime() == otherAct.getStartTime()

--- a/src/main/java/gomedic/model/commonfield/exceptions/MaxAddressBookCapacityReached.java
+++ b/src/main/java/gomedic/model/commonfield/exceptions/MaxAddressBookCapacityReached.java
@@ -1,0 +1,10 @@
+package gomedic.model.commonfield.exceptions;
+
+/**
+ * Signals that the operation is unable to support more items.
+ */
+public class MaxAddressBookCapacityReached extends RuntimeException {
+    public MaxAddressBookCapacityReached() {
+        super("The addressbook can only contains max of 999 items of each type at one point of time.");
+    }
+}

--- a/src/main/java/gomedic/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/gomedic/storage/JsonSerializableAddressBook.java
@@ -49,7 +49,10 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
-        activities.addAll(source.getActivityList().stream().map(JsonAdaptedActivity::new).collect(Collectors.toList()));
+        activities.addAll(source
+                .getActivityListSortedById()
+                .stream()
+                .map(JsonAdaptedActivity::new).collect(Collectors.toList()));
         doctors.addAll(source.getDoctorList().stream().map(JsonAdaptedDoctor::new).collect(Collectors.toList()));
     }
 

--- a/src/main/java/gomedic/ui/MainWindow.java
+++ b/src/main/java/gomedic/ui/MainWindow.java
@@ -8,7 +8,9 @@ import gomedic.logic.Logic;
 import gomedic.logic.commands.CommandResult;
 import gomedic.logic.commands.exceptions.CommandException;
 import gomedic.logic.parser.exceptions.ParseException;
+import gomedic.ui.panel.ActivityListPanel;
 import gomedic.ui.panel.PersonListPanel;
+import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
@@ -31,17 +33,22 @@ public class MainWindow extends UiPart<Stage> {
     private final Stage primaryStage;
     private final Logic logic;
     private final HelpWindow helpWindow;
+
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private ActivityListPanel activityListPanel;
+
     private ResultDisplay resultDisplay;
+
     @FXML
     private StackPane commandBoxPlaceholder;
 
     @FXML
     private MenuItem helpMenuItem;
 
+    // Important Region where we can swap the root to change the UI.
     @FXML
-    private StackPane personListPanelPlaceholder;
+    private StackPane modelListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -65,6 +72,24 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
+        // Value to indicate what model is currently being shown.
+        // 0 -> Activity, 1 -> Person
+        ObservableValue<Integer> modelItemBeingShown = logic.getModelBeingShown();
+        modelItemBeingShown.addListener((obs, oldVal, newVal) -> {
+            modelListPanelPlaceholder.getChildren().clear();
+            switch (newVal) {
+            case 0:
+                modelListPanelPlaceholder.getChildren().add(activityListPanel.getRoot());
+                break;
+            case 1:
+                modelListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+                break;
+            default:
+                // do nothing
+                break;
+            }
+        });
     }
 
     public Stage getPrimaryStage() {
@@ -111,7 +136,10 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        activityListPanel = new ActivityListPanel(logic.getFilteredActivityList());
+
+        // by default, show the activity first
+        modelListPanelPlaceholder.getChildren().add(activityListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -148,7 +176,8 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     void show() {
-        primaryStage.setMaximized(true);
+        //  set full-screen if wanted
+        //  primaryStage.setMaximized(true);
         primaryStage.show();
     }
 
@@ -166,6 +195,10 @@ public class MainWindow extends UiPart<Stage> {
 
     public PersonListPanel getPersonListPanel() {
         return personListPanel;
+    }
+
+    public ActivityListPanel getActivityListPanel() {
+        return activityListPanel;
     }
 
     /**

--- a/src/main/java/gomedic/ui/MainWindow.java
+++ b/src/main/java/gomedic/ui/MainWindow.java
@@ -8,6 +8,7 @@ import gomedic.logic.Logic;
 import gomedic.logic.commands.CommandResult;
 import gomedic.logic.commands.exceptions.CommandException;
 import gomedic.logic.parser.exceptions.ParseException;
+import gomedic.ui.panel.PersonListPanel;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
@@ -147,6 +148,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     void show() {
+        primaryStage.setMaximized(true);
         primaryStage.show();
     }
 

--- a/src/main/java/gomedic/ui/UiManager.java
+++ b/src/main/java/gomedic/ui/UiManager.java
@@ -85,5 +85,4 @@ public class UiManager implements Ui {
         Platform.exit();
         System.exit(1);
     }
-
 }

--- a/src/main/java/gomedic/ui/UiPart.java
+++ b/src/main/java/gomedic/ui/UiPart.java
@@ -37,6 +37,23 @@ public abstract class UiPart<T> {
     }
 
     /**
+     * Constructs a UiPart with the specified FXML file within {@link #FXML_FILE_FOLDER} and root object.
+     *
+     * @see #UiPart(URL, T)
+     */
+    public UiPart(String fxmlFileName, T root) {
+        this(getFxmlFileUrl(fxmlFileName), root);
+    }
+
+    /**
+     * Constructs a UiPart with the specified FXML file URL and root object.
+     * The FXML file must not specify the {@code fx:controller} attribute.
+     */
+    public UiPart(URL fxmlFileUrl, T root) {
+        loadFxmlFile(fxmlFileUrl, root);
+    }
+
+    /**
      * Returns the FXML file URL for the specified FXML file name within {@link #FXML_FILE_FOLDER}.
      */
     private static URL getFxmlFileUrl(String fxmlFileName) {
@@ -62,23 +79,6 @@ public abstract class UiPart<T> {
         } catch (IOException e) {
             throw new AssertionError(e);
         }
-    }
-
-    /**
-     * Constructs a UiPart with the specified FXML file within {@link #FXML_FILE_FOLDER} and root object.
-     *
-     * @see #UiPart(URL, T)
-     */
-    public UiPart(String fxmlFileName, T root) {
-        this(getFxmlFileUrl(fxmlFileName), root);
-    }
-
-    /**
-     * Constructs a UiPart with the specified FXML file URL and root object.
-     * The FXML file must not specify the {@code fx:controller} attribute.
-     */
-    public UiPart(URL fxmlFileUrl, T root) {
-        loadFxmlFile(fxmlFileUrl, root);
     }
 
     /**

--- a/src/main/java/gomedic/ui/UiPart.java
+++ b/src/main/java/gomedic/ui/UiPart.java
@@ -20,14 +20,6 @@ public abstract class UiPart<T> {
     private final FXMLLoader fxmlLoader = new FXMLLoader();
 
     /**
-     * Constructs a UiPart with the specified FXML file URL.
-     * The FXML file must not specify the {@code fx:controller} attribute.
-     */
-    public UiPart(URL fxmlFileUrl) {
-        loadFxmlFile(fxmlFileUrl, null);
-    }
-
-    /**
      * Constructs a UiPart using the specified FXML file within {@link #FXML_FILE_FOLDER}.
      *
      * @see #UiPart(URL)
@@ -37,20 +29,11 @@ public abstract class UiPart<T> {
     }
 
     /**
-     * Constructs a UiPart with the specified FXML file URL and root object.
+     * Constructs a UiPart with the specified FXML file URL.
      * The FXML file must not specify the {@code fx:controller} attribute.
      */
-    public UiPart(URL fxmlFileUrl, T root) {
-        loadFxmlFile(fxmlFileUrl, root);
-    }
-
-    /**
-     * Constructs a UiPart with the specified FXML file within {@link #FXML_FILE_FOLDER} and root object.
-     *
-     * @see #UiPart(URL, T)
-     */
-    public UiPart(String fxmlFileName, T root) {
-        this(getFxmlFileUrl(fxmlFileName), root);
+    public UiPart(URL fxmlFileUrl) {
+        loadFxmlFile(fxmlFileUrl, null);
     }
 
     /**
@@ -61,13 +44,6 @@ public abstract class UiPart<T> {
         String fxmlFileNameWithFolder = FXML_FILE_FOLDER + fxmlFileName;
         URL fxmlFileUrl = MainApp.class.getResource(fxmlFileNameWithFolder);
         return requireNonNull(fxmlFileUrl);
-    }
-
-    /**
-     * Returns the root object of the scene graph of this UiPart.
-     */
-    public T getRoot() {
-        return fxmlLoader.getRoot();
     }
 
     /**
@@ -86,6 +62,30 @@ public abstract class UiPart<T> {
         } catch (IOException e) {
             throw new AssertionError(e);
         }
+    }
+
+    /**
+     * Constructs a UiPart with the specified FXML file within {@link #FXML_FILE_FOLDER} and root object.
+     *
+     * @see #UiPart(URL, T)
+     */
+    public UiPart(String fxmlFileName, T root) {
+        this(getFxmlFileUrl(fxmlFileName), root);
+    }
+
+    /**
+     * Constructs a UiPart with the specified FXML file URL and root object.
+     * The FXML file must not specify the {@code fx:controller} attribute.
+     */
+    public UiPart(URL fxmlFileUrl, T root) {
+        loadFxmlFile(fxmlFileUrl, root);
+    }
+
+    /**
+     * Returns the root object of the scene graph of this UiPart.
+     */
+    public T getRoot() {
+        return fxmlLoader.getRoot();
     }
 
 }

--- a/src/main/java/gomedic/ui/card/ActivityCard.java
+++ b/src/main/java/gomedic/ui/card/ActivityCard.java
@@ -40,10 +40,10 @@ public class ActivityCard extends UiPart<Region> {
     /**
      * Creates a {@code ActivityCode} with the given {@code Activity} and index to display.
      */
-    public ActivityCard(Activity activity, int displayedIndex) {
+    public ActivityCard(Activity activity) {
         super(FXML);
         this.activity = activity;
-        id.setText(activity.toString());
+        id.setText(activity.getActivityId().toString() + ".");
         title.setText(activity.getTitle().toString());
         description.setText(activity.getDescription().toString());
         startTime.setText(activity.getStartTime().toString());

--- a/src/main/java/gomedic/ui/card/ActivityCard.java
+++ b/src/main/java/gomedic/ui/card/ActivityCard.java
@@ -1,0 +1,69 @@
+package gomedic.ui.card;
+
+import gomedic.model.activity.Activity;
+import gomedic.ui.UiPart;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+
+/**
+ * An UI component that displays information of a {@code Activity}.
+ */
+public class ActivityCard extends UiPart<Region> {
+
+    private static final String FXML = "ActivityListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Activity activity;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label id;
+    @FXML
+    private Label title;
+    @FXML
+    private Label description;
+    @FXML
+    private Label endTime;
+    @FXML
+    private Label startTime;
+
+    /**
+     * Creates a {@code ActivityCode} with the given {@code Activity} and index to display.
+     */
+    public ActivityCard(Activity activity, int displayedIndex) {
+        super(FXML);
+        this.activity = activity;
+        id.setText(activity.toString());
+        title.setText(activity.getTitle().toString());
+        description.setText(activity.getDescription().toString());
+        startTime.setText(activity.getStartTime().toString());
+        endTime.setText(activity.getEndTime().toString());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ActivityCard)) {
+            return false;
+        }
+
+        // state check
+        ActivityCard card = (ActivityCard) other;
+        return activity.equals(card.activity);
+    }
+}

--- a/src/main/java/gomedic/ui/card/PersonCard.java
+++ b/src/main/java/gomedic/ui/card/PersonCard.java
@@ -1,8 +1,9 @@
-package gomedic.ui;
+package gomedic.ui.card;
 
 import java.util.Comparator;
 
 import gomedic.model.person.Person;
+import gomedic.ui.UiPart;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;

--- a/src/main/java/gomedic/ui/panel/ActivityListPanel.java
+++ b/src/main/java/gomedic/ui/panel/ActivityListPanel.java
@@ -4,9 +4,8 @@ import java.util.logging.Logger;
 
 import gomedic.commons.core.LogsCenter;
 import gomedic.model.activity.Activity;
-import gomedic.ui.card.ActivityCard;
-import gomedic.ui.card.PersonCard;
 import gomedic.ui.UiPart;
+import gomedic.ui.card.ActivityCard;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -17,7 +16,7 @@ import javafx.scene.layout.Region;
  * Panel containing the list of persons.
  */
 public class ActivityListPanel extends UiPart<Region> {
-    private static final String FXML = "PersonListPanel.fxml";
+    private static final String FXML = "ActivityListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(ActivityListPanel.class);
 
     @FXML
@@ -44,7 +43,7 @@ public class ActivityListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new ActivityCard(activity, getIndex() + 1).getRoot());
+                setGraphic(new ActivityCard(activity).getRoot());
             }
         }
     }

--- a/src/main/java/gomedic/ui/panel/ActivityListPanel.java
+++ b/src/main/java/gomedic/ui/panel/ActivityListPanel.java
@@ -1,0 +1,52 @@
+package gomedic.ui.panel;
+
+import java.util.logging.Logger;
+
+import gomedic.commons.core.LogsCenter;
+import gomedic.model.activity.Activity;
+import gomedic.ui.card.ActivityCard;
+import gomedic.ui.card.PersonCard;
+import gomedic.ui.UiPart;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+
+/**
+ * Panel containing the list of persons.
+ */
+public class ActivityListPanel extends UiPart<Region> {
+    private static final String FXML = "PersonListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ActivityListPanel.class);
+
+    @FXML
+    private ListView<Activity> activityListView;
+
+    /**
+     * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
+     */
+    public ActivityListPanel(ObservableList<Activity> activityList) {
+        super(FXML);
+        activityListView.setItems(activityList);
+        activityListView.setCellFactory(listView -> new ActivityListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Activity} using a {@code ActivityCard}.
+     */
+    static class ActivityListViewCell extends ListCell<Activity> {
+        @Override
+        protected void updateItem(Activity activity, boolean empty) {
+            super.updateItem(activity, empty);
+
+            if (empty || activity == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new ActivityCard(activity, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/java/gomedic/ui/panel/PersonListPanel.java
+++ b/src/main/java/gomedic/ui/panel/PersonListPanel.java
@@ -4,8 +4,8 @@ import java.util.logging.Logger;
 
 import gomedic.commons.core.LogsCenter;
 import gomedic.model.person.Person;
-import gomedic.ui.card.PersonCard;
 import gomedic.ui.UiPart;
+import gomedic.ui.card.PersonCard;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;

--- a/src/main/java/gomedic/ui/panel/PersonListPanel.java
+++ b/src/main/java/gomedic/ui/panel/PersonListPanel.java
@@ -1,9 +1,11 @@
-package gomedic.ui;
+package gomedic.ui.panel;
 
 import java.util.logging.Logger;
 
 import gomedic.commons.core.LogsCenter;
 import gomedic.model.person.Person;
+import gomedic.ui.card.PersonCard;
+import gomedic.ui.UiPart;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -32,7 +34,7 @@ public class PersonListPanel extends UiPart<Region> {
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
-    class PersonListViewCell extends ListCell<Person> {
+    static class PersonListViewCell extends ListCell<Person> {
         @Override
         protected void updateItem(Person person, boolean empty) {
             super.updateItem(person, empty);

--- a/src/main/resources/view/ActivityListCard.fxml
+++ b/src/main/resources/view/ActivityListCard.fxml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15"/>
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE"/>
+                    </minWidth>
+                </Label>
+                <Label fx:id="title" text="\$title" styleClass="cell_big_label"/>
+            </HBox>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label styleClass="cell_small_label" text="Time: "/>
+                <Label fx:id="startTime" styleClass="cell_small_label" text="\$startTime"/>
+                <Label styleClass="cell_small_label" text="To"/>
+                <Label fx:id="endTime" styleClass="cell_small_label" text="\$endTime"/>
+            </HBox>
+            <Label fx:id="description" styleClass="cell_small_label" text="\$description"/>
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/ActivityListPanel.fxml
+++ b/src/main/resources/view/ActivityListPanel.fxml
@@ -3,5 +3,5 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <ListView fx:id="personListView" VBox.vgrow="ALWAYS"/>
+    <ListView fx:id="activityListView" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -2,60 +2,60 @@
 
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.Scene?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
+<?import javafx.scene.Scene?>
+<?import javafx.stage.Stage?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
-  <icons>
-    <Image url="@/images/address_book_32.png" />
-  </icons>
-  <scene>
-    <Scene>
-      <stylesheets>
-        <URL value="@Fonts.css"/>
-        <URL value="@LightTheme.css" />
-        <URL value="@Extensions.css" />
-      </stylesheets>
+    <icons>
+        <Image url="@/images/address_book_32.png"/>
+    </icons>
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@Fonts.css"/>
+                <URL value="@LightTheme.css"/>
+                <URL value="@Extensions.css"/>
+            </stylesheets>
 
-      <VBox>
-        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
-          <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </Menu>
-          <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-          </Menu>
-        </MenuBar>
+            <VBox>
+                <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
+                    <Menu mnemonicParsing="false" text="File">
+                        <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit"/>
+                    </Menu>
+                    <Menu mnemonicParsing="false" text="Help">
+                        <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help"/>
+                    </Menu>
+                </MenuBar>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
+                <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+                    <padding>
+                        <Insets top="5" right="10" bottom="5" left="10"/>
+                    </padding>
+                </StackPane>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
+                <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
+                           minHeight="100" prefHeight="100" maxHeight="100">
+                    <padding>
+                        <Insets top="5" right="10" bottom="5" left="10"/>
+                    </padding>
+                </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+                <VBox fx:id="modelList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
+                      VBox.vgrow="ALWAYS">
+                    <padding>
+                        <Insets top="10" right="10" bottom="10" left="10"/>
+                    </padding>
+                    <StackPane fx:id="modelListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                </VBox>
 
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-      </VBox>
-    </Scene>
-  </scene>
+                <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
+            </VBox>
+        </Scene>
+    </scene>
 </fx:root>

--- a/src/test/java/gomedic/logic/LogicManagerTest.java
+++ b/src/test/java/gomedic/logic/LogicManagerTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.io.TempDir;
 import gomedic.commons.core.Messages;
 import gomedic.logic.commands.CommandResult;
 import gomedic.logic.commands.CommandTestUtil;
-import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.commands.addcommand.AddActivityCommand;
 import gomedic.logic.commands.addcommand.AddPersonCommand;
 import gomedic.logic.commands.exceptions.CommandException;
+import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.parser.exceptions.ParseException;
 import gomedic.model.Model;
 import gomedic.model.ModelManager;
@@ -179,6 +179,18 @@ public class LogicManagerTest {
     @Test
     public void getFilteredActivityList_modifyList_throwsUnsupportedOperationException() {
         Assert.assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredActivityList().remove(0));
+    }
+
+    @Test
+    void getModelBeingShown_defaultValue_testPassed() {
+        assertEquals(0, logic.getModelBeingShown().getValue());
+    }
+
+    @Test
+    void getModelBeingShown_executeOtherCommand_testPassed() throws Exception {
+        String listCommand = ListPersonCommand.COMMAND_WORD;
+        assertCommandSuccess(listCommand, ListPersonCommand.MESSAGE_SUCCESS, model);
+        assertEquals(1, logic.getModelBeingShown().getValue());
     }
 
     /**

--- a/src/test/java/gomedic/logic/LogicManagerTest.java
+++ b/src/test/java/gomedic/logic/LogicManagerTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 import gomedic.commons.core.Messages;
 import gomedic.logic.commands.CommandResult;
 import gomedic.logic.commands.CommandTestUtil;
-import gomedic.logic.commands.ListCommand;
+import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.commands.addcommand.AddActivityCommand;
 import gomedic.logic.commands.addcommand.AddPersonCommand;
 import gomedic.logic.commands.exceptions.CommandException;
@@ -106,8 +106,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        String listCommand = ListPersonCommand.COMMAND_WORD;
+        assertCommandSuccess(listCommand, ListPersonCommand.MESSAGE_SUCCESS, model);
     }
 
     /**

--- a/src/test/java/gomedic/logic/commands/CommandTestUtil.java
+++ b/src/test/java/gomedic/logic/commands/CommandTestUtil.java
@@ -13,6 +13,8 @@ import gomedic.logic.commands.exceptions.CommandException;
 import gomedic.logic.parser.CliSyntax;
 import gomedic.model.AddressBook;
 import gomedic.model.Model;
+import gomedic.model.activity.Activity;
+import gomedic.model.activity.ActivityId;
 import gomedic.model.person.Person;
 import gomedic.model.util.NameContainsKeywordsPredicate;
 import gomedic.testutil.EditPersonDescriptorBuilder;
@@ -116,6 +118,7 @@ public class CommandTestUtil {
                                             Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
+
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
@@ -154,4 +157,17 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show only the activity at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showActivityAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredActivityList().size());
+
+        Activity activity = model.getFilteredActivityList().get(targetIndex.getZeroBased());
+        final ActivityId aid = activity.getActivityId();
+        model.updateFilteredActivitiesList(activity1 -> activity1.getActivityId().equals(aid));
+
+        assertEquals(1, model.getFilteredActivityList().size());
+    }
 }

--- a/src/test/java/gomedic/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/DeleteCommandTest.java
@@ -1,7 +1,7 @@
 package gomedic.logic.commands;
 
-import static gomedic.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static gomedic.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
+import static gomedic.testutil.TypicalIndexes.INDEX_SECOND;
 import static gomedic.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,8 +25,8 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -46,10 +46,10 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        CommandTestUtil.showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        CommandTestUtil.showPersonAtIndex(model, INDEX_FIRST);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -62,9 +62,9 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        CommandTestUtil.showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        CommandTestUtil.showPersonAtIndex(model, INDEX_FIRST);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -75,14 +75,14 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/gomedic/logic/commands/EditCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/EditCommandTest.java
@@ -8,8 +8,8 @@ import static gomedic.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static gomedic.logic.commands.CommandTestUtil.assertCommandFailure;
 import static gomedic.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static gomedic.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static gomedic.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static gomedic.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
+import static gomedic.testutil.TypicalIndexes.INDEX_SECOND;
 import static gomedic.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,7 +37,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Person editedPerson = new PersonBuilder().build();
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -70,8 +70,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditCommand.EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, new EditCommand.EditPersonDescriptor());
+        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -82,11 +82,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
@@ -99,20 +99,20 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
         // edit person in filtered list into a duplicate in address book
-        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder(personInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
@@ -134,8 +134,8 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        showPersonAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -147,11 +147,11 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST, DESC_AMY);
 
         // same values -> returns true
         EditCommand.EditPersonDescriptor copyDescriptor = new EditCommand.EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -164,10 +164,10 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST, DESC_BOB)));
     }
 
 }

--- a/src/test/java/gomedic/logic/commands/ListPersonCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/ListPersonCommandTest.java
@@ -8,6 +8,7 @@ import static gomedic.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.model.Model;
 import gomedic.model.ModelManager;
 import gomedic.model.UserPrefs;
@@ -15,7 +16,7 @@ import gomedic.model.UserPrefs;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
  */
-public class ListCommandTest {
+public class ListPersonCommandTest {
 
     private Model model;
     private Model expectedModel;
@@ -28,12 +29,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListPersonCommand(), model, ListPersonCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListPersonCommand(), model, ListPersonCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/gomedic/logic/commands/addcommand/AddActivityCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/addcommand/AddActivityCommandTest.java
@@ -19,11 +19,13 @@ import gomedic.logic.commands.CommandResult;
 import gomedic.logic.commands.exceptions.CommandException;
 import gomedic.model.AddressBook;
 import gomedic.model.Model;
+import gomedic.model.ModelItem;
 import gomedic.model.ReadOnlyAddressBook;
 import gomedic.model.ReadOnlyUserPrefs;
 import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
 import gomedic.testutil.modelbuilder.ActivityBuilder;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 
 class AddActivityCommandTest {
@@ -209,6 +211,21 @@ class AddActivityCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<? super Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredActivitiesList(Predicate<? super Activity> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableValue<Integer> getModelBeingShown() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setModelBeingShown(ModelItem modelItem) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/gomedic/logic/commands/addcommand/AddActivityIntegrationTest.java
+++ b/src/test/java/gomedic/logic/commands/addcommand/AddActivityIntegrationTest.java
@@ -50,7 +50,7 @@ public class AddActivityIntegrationTest {
 
     @Test
     public void execute_conflictingActivity_throwsCommandException() {
-        Activity activityInList = model.getAddressBook().getActivityList().get(0);
+        Activity activityInList = model.getAddressBook().getActivityListSortedById().get(0);
         CommandTestUtil.assertCommandFailure(
                 new AddActivityCommand(
                         activityInList.getStartTime(),

--- a/src/test/java/gomedic/logic/commands/addcommand/AddPersonCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/addcommand/AddPersonCommandTest.java
@@ -17,11 +17,13 @@ import gomedic.logic.commands.CommandResult;
 import gomedic.logic.commands.exceptions.CommandException;
 import gomedic.model.AddressBook;
 import gomedic.model.Model;
+import gomedic.model.ModelItem;
 import gomedic.model.ReadOnlyAddressBook;
 import gomedic.model.ReadOnlyUserPrefs;
 import gomedic.model.activity.Activity;
 import gomedic.model.person.Person;
 import gomedic.testutil.modelbuilder.PersonBuilder;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 
 public class AddPersonCommandTest {
@@ -172,6 +174,21 @@ public class AddPersonCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<? super Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredActivitiesList(Predicate<? super Activity> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableValue<Integer> getModelBeingShown() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setModelBeingShown(ModelItem modelItem) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/gomedic/logic/commands/listcommand/ListActivityCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/listcommand/ListActivityCommandTest.java
@@ -1,0 +1,35 @@
+package gomedic.logic.commands.listcommand;
+
+import static gomedic.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static gomedic.logic.commands.CommandTestUtil.showActivityAtIndex;
+import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
+import static gomedic.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import gomedic.model.Model;
+import gomedic.model.ModelManager;
+import gomedic.model.UserPrefs;
+
+class ListActivityCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListActivityCommand(), model, ListActivityCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showActivityAtIndex(model, INDEX_FIRST);
+        assertCommandSuccess(new ListActivityCommand(), model, ListActivityCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/gomedic/logic/commands/listcommand/ListPersonCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/listcommand/ListPersonCommandTest.java
@@ -1,14 +1,13 @@
-package gomedic.logic.commands;
+package gomedic.logic.commands.listcommand;
 
 import static gomedic.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static gomedic.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static gomedic.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
 import static gomedic.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.model.Model;
 import gomedic.model.ModelManager;
 import gomedic.model.UserPrefs;
@@ -34,7 +33,7 @@ public class ListPersonCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
         assertCommandSuccess(new ListPersonCommand(), model, ListPersonCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/gomedic/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/gomedic/logic/parser/AddressBookParserTest.java
@@ -17,6 +17,7 @@ import gomedic.logic.commands.ExitCommand;
 import gomedic.logic.commands.FindCommand;
 import gomedic.logic.commands.HelpCommand;
 import gomedic.logic.commands.addcommand.AddPersonCommand;
+import gomedic.logic.commands.listcommand.ListActivityCommand;
 import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.parser.exceptions.ParseException;
 import gomedic.model.person.Person;
@@ -81,9 +82,16 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_list() throws Exception {
+    public void parseCommand_listPerson() throws Exception {
         assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD) instanceof ListPersonCommand);
         assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD + " 3") instanceof ListPersonCommand);
+    }
+
+
+    @Test
+    public void parseCommand_listActivity() throws Exception {
+        assertTrue(parser.parseCommand(ListActivityCommand.COMMAND_WORD) instanceof ListActivityCommand);
+        assertTrue(parser.parseCommand(ListActivityCommand.COMMAND_WORD + " 3") instanceof ListActivityCommand);
     }
 
     @Test

--- a/src/test/java/gomedic/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/gomedic/logic/parser/AddressBookParserTest.java
@@ -16,8 +16,8 @@ import gomedic.logic.commands.EditCommand;
 import gomedic.logic.commands.ExitCommand;
 import gomedic.logic.commands.FindCommand;
 import gomedic.logic.commands.HelpCommand;
-import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.commands.addcommand.AddPersonCommand;
+import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.parser.exceptions.ParseException;
 import gomedic.model.person.Person;
 import gomedic.model.util.NameContainsKeywordsPredicate;
@@ -46,8 +46,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + TypicalIndexes.INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST), command);
     }
 
     @Test
@@ -55,9 +55,9 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased()
+                + TypicalIndexes.INDEX_FIRST.getOneBased()
                 + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditCommand(TypicalIndexes.INDEX_FIRST, descriptor), command);
     }
 
     @Test

--- a/src/test/java/gomedic/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/gomedic/logic/parser/AddressBookParserTest.java
@@ -16,7 +16,7 @@ import gomedic.logic.commands.EditCommand;
 import gomedic.logic.commands.ExitCommand;
 import gomedic.logic.commands.FindCommand;
 import gomedic.logic.commands.HelpCommand;
-import gomedic.logic.commands.ListCommand;
+import gomedic.logic.commands.listcommand.ListPersonCommand;
 import gomedic.logic.commands.addcommand.AddPersonCommand;
 import gomedic.logic.parser.exceptions.ParseException;
 import gomedic.model.person.Person;
@@ -82,8 +82,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD) instanceof ListPersonCommand);
+        assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD + " 3") instanceof ListPersonCommand);
     }
 
     @Test

--- a/src/test/java/gomedic/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/gomedic/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,6 @@
 package gomedic.logic.parser;
 
-import static gomedic.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +20,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        CommandParserTestUtil.assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        CommandParserTestUtil.assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/gomedic/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/gomedic/logic/parser/EditCommandParserTest.java
@@ -1,8 +1,8 @@
 package gomedic.logic.parser;
 
-import static gomedic.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static gomedic.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static gomedic.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
+import static gomedic.testutil.TypicalIndexes.INDEX_SECOND;
+import static gomedic.testutil.TypicalIndexes.INDEX_THIRD;
 
 import org.junit.jupiter.api.Test;
 
@@ -98,7 +98,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
+        Index targetIndex = INDEX_SECOND;
         String userInput = targetIndex.getOneBased()
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.TAG_DESC_HUSBAND
                 + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY
@@ -116,7 +116,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_AMY;
 
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
@@ -130,7 +130,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + CommandTestUtil.NAME_DESC_AMY;
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
                 .withName(CommandTestUtil.VALID_NAME_AMY)
@@ -165,7 +165,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased()
                 + CommandTestUtil.PHONE_DESC_AMY
                 + CommandTestUtil.ADDRESS_DESC_AMY
@@ -194,7 +194,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased()
                 + CommandTestUtil.INVALID_PHONE_DESC
                 + CommandTestUtil.PHONE_DESC_BOB;
@@ -219,7 +219,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();

--- a/src/test/java/gomedic/logic/parser/ParserUtilTest.java
+++ b/src/test/java/gomedic/logic/parser/ParserUtilTest.java
@@ -1,7 +1,7 @@
 package gomedic.logic.parser;
 
 import static gomedic.testutil.Assert.assertThrows;
-import static gomedic.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,10 +62,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/gomedic/model/AddressBookTest.java
+++ b/src/test/java/gomedic/model/AddressBookTest.java
@@ -45,7 +45,7 @@ public class AddressBookTest {
     public void constructor() {
         assertEquals(Collections.emptyList(), addressBook.getPersonList());
         assertEquals(Collections.emptyList(), addressBook.getDoctorList());
-        assertEquals(Collections.emptyList(), addressBook.getActivityList());
+        assertEquals(Collections.emptyList(), addressBook.getActivityListSortedById());
         assertEquals(Collections.emptyList(), addressBook.getActivityListSortedStartTime());
     }
 
@@ -167,7 +167,7 @@ public class AddressBookTest {
 
     @Test
     public void getActivityList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> addressBook.getActivityList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> addressBook.getActivityListSortedById().remove(0));
     }
 
     @Test
@@ -211,7 +211,7 @@ public class AddressBookTest {
         addressBook.addActivity(PAST_ACTIVITY);
         addressBook.addActivity(MEETING);
 
-        assertEquals(addressBook.getActivityList(), addressBook.getActivityListSortedStartTime());
+        assertEquals(List.of(PAST_ACTIVITY, MEETING), addressBook.getActivityListSortedStartTime());
     }
 
     @Test
@@ -269,7 +269,7 @@ public class AddressBookTest {
         }
 
         @Override
-        public ObservableList<Activity> getActivityList() {
+        public ObservableList<Activity> getActivityListSortedById() {
             return activities;
         }
 

--- a/src/test/java/gomedic/model/ModelManagerTest.java
+++ b/src/test/java/gomedic/model/ModelManagerTest.java
@@ -3,6 +3,7 @@ package gomedic.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -156,5 +157,21 @@ public class ModelManagerTest {
     public void getFilteredActivityList_modifyList_throwsUnsupportedOperationException() {
         Assert.assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredActivityList()
                 .remove(0));
+    }
+
+    @Test
+    void getModelBeingShown_validInput_testPassed() {
+        assertEquals(0, modelManager.getModelBeingShown().getValue());
+    }
+
+    @Test
+    void setModelBeingShown_validInput_testPassed() {
+        modelManager.setModelBeingShown(ModelItem.PERSON);
+        assertEquals(1, modelManager.getModelBeingShown().getValue());
+    }
+
+    @Test
+    void setModelBeingShown_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setModelBeingShown(null));
     }
 }

--- a/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
+++ b/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
@@ -97,7 +97,7 @@ class UniqueActivityListTest {
         uniqueActivityList.add(PAPER_REVIEW);
         UniqueActivityList expectedUniqueActivityList = new UniqueActivityList();
         expectedUniqueActivityList.add(MEETING);
-        uniqueActivityList.setActivities(expectedUniqueActivityList.asUnmodifiableObservableList());
+        uniqueActivityList.setActivities(expectedUniqueActivityList.asUnmodifiableSortedByIdObservableList());
         assertEquals(expectedUniqueActivityList, uniqueActivityList);
     }
 
@@ -130,14 +130,14 @@ class UniqueActivityListTest {
     @Test
     public void asUnmodifiableObservableList() {
         uniqueActivityList.setActivities(getTypicalActivities());
-        assertEquals(getTypicalActivities(), uniqueActivityList.asUnmodifiableObservableList());
+        assertEquals(getTypicalActivities(), uniqueActivityList.asUnmodifiableSortedByIdObservableList());
     }
 
     @Test
     public void asUnmodifiableSortedList_typicalList_sortedByStartingTime() {
         uniqueActivityList.setActivities(getTypicalActivities());
         Activity prev = null;
-        for (Activity a : uniqueActivityList.asUnmodifiableSortedList()) {
+        for (Activity a : uniqueActivityList.asUnmodifiableSortedByStartTimeList()) {
             if (prev == null) {
                 prev = a;
             } else {
@@ -149,7 +149,8 @@ class UniqueActivityListTest {
     @Test
     public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(
-                UnsupportedOperationException.class, () -> uniqueActivityList.asUnmodifiableObservableList().remove(0)
+                UnsupportedOperationException.class, () -> uniqueActivityList
+                        .asUnmodifiableSortedByIdObservableList().remove(0)
         );
     }
 

--- a/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
+++ b/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import gomedic.model.activity.exceptions.ActivityNotFoundException;
 import gomedic.model.activity.exceptions.ConflictingActivityException;
 import gomedic.model.activity.exceptions.DuplicateActivityFoundException;
+import gomedic.model.commonfield.exceptions.MaxAddressBookCapacityReached;
+import gomedic.testutil.modelbuilder.ActivityBuilder;
 
 class UniqueActivityListTest {
     private final UniqueActivityList uniqueActivityList = new UniqueActivityList();
@@ -38,6 +40,32 @@ class UniqueActivityListTest {
     void add_normal_returnsTrue() {
         uniqueActivityList.add(MEETING);
         assertTrue(uniqueActivityList.contains(MEETING));
+    }
+
+    @Test
+    void add_maxCapacity_throwsMaxCapacityReached() {
+        String startTime = "%02d/%02d/%04d 15:00";
+        String endTime = "%02d/%02d/%04d 16:00";
+
+        Runnable r = () -> {
+            for (int day = 1; day < 28; day++) {
+                for (int month = 1; month < 12; month++) {
+                    for (int year = 2000; year < 2100; year++) {
+                        Activity a = new ActivityBuilder()
+                                .withId(uniqueActivityList.getNewActivityId())
+                                .withTitle("test")
+                                .withStartTime(String.format(startTime, day, month, year))
+                                .withEndTime(String.format(endTime, day, month, year))
+                                .build();
+
+                        uniqueActivityList.add(a);
+                    }
+                }
+            }
+        };
+
+        assertThrows(MaxAddressBookCapacityReached.class, r::run);
+
     }
 
     @Test

--- a/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
+++ b/src/test/java/gomedic/model/activity/UniqueActivityListTest.java
@@ -156,7 +156,7 @@ class UniqueActivityListTest {
     @Test
     void getLastActivityId_validInput_testsPassed() {
         uniqueActivityList.setActivities(getTypicalActivities());
-        assertEquals(5, uniqueActivityList.getNewActivityId());
+        assertEquals(2, uniqueActivityList.getNewActivityId());
     }
 
     @Test

--- a/src/test/java/gomedic/testutil/TypicalIndexes.java
+++ b/src/test/java/gomedic/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import gomedic.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD = Index.fromOneBased(3);
 }


### PR DESCRIPTION
### Summary

* Finish adding the command `list t/activity` , Resolves #64 
* the existing command `list` is refactored to `list t/person` 

### Detail

* UI uses `ObservableValue` to keep track of what is being shown currently, which is ultimately shown in the `Model`, but accessed by UI only through Logic (I think Logic.Model.get sth violates demeter law) 
* Add more testing
* Integrate Yuhang suggestion that the Id, instead of getting last + 1, show the missing id and use that for e.g 1 2 5 -> `getNewId` would return 3, and hence we need to sort by Id (otherwise everytime we add, it would lead to unsorted Id which is pretty ugly) 
* Currently, the UI for activity is almost the same with the Person Card, already separated the UI however (There is `personList` and `activityList`)

### Pictures / Gif

* Listing activity
![image](https://user-images.githubusercontent.com/51783522/136686961-a187d471-1497-49fe-810c-05f308480aac.png)

* Listing persons
![image](https://user-images.githubusercontent.com/51783522/136686975-0928226e-3da9-495e-ac69-3bb19a15de1d.png)

### Checks

- [x] Link PR to issue
- [x] Add Reviewer
- [x] Pass CI
