### PR TITLE
Abstract out shared variables for more reusability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,16 +6,6 @@ plugins {
     id 'jacoco'
 }
 
-compileJava {
-    options.encoding = 'UTF-8'
-    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-}
-
-compileTestJava {
-    options.encoding = 'UTF-8'
-    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-}
-
 mainClassName = 'gomedic.Main'
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -153,11 +153,11 @@ Examples:
 
 * `delete t/patient i/P001`
 
-### Updating an existing patient: `update t/patient`
+### Updating an existing patient: `edit t/patient`
 
-Updates a patient's details from the GoMedic application.
+Edits a patient's details from the GoMedic application.
 
-Format: `update t/patient i/PATIENT_ID [OPTIONAL_PARAMETER]...`
+Format: `edit t/patient i/PATIENT_ID [OPTIONAL_PARAMETER]...`
 
 The parameters are:
 
@@ -185,9 +185,9 @@ Notes:
 
 Examples:
 
-* `update t/patient i/P123 n/John Doe a/30 g/M`
-* `update t/patient i/P003 n/Tom Doe a/20 g/M h/167 w/61 b/AB p/12341234 do/diabetes`
-* `update t/patient i/P003 n/Tom Doe a/20 g/M h/167 w/61 b/AB p/12341234 o/fever o/headache do/diabetes do/heart feailure`
+* `edit t/patient i/P123 n/John Doe a/30 g/M`
+* `edit t/patient i/P003 n/Tom Doe a/20 g/M h/167 w/61 b/AB p/12341234 do/diabetes`
+* `edit t/patient i/P003 n/Tom Doe a/20 g/M h/167 w/61 b/AB p/12341234 o/fever o/headache do/diabetes do/heart feailure`
 
 ### Viewing the list of patients `list t/patient`
 
@@ -251,11 +251,11 @@ Examples:
 
 * `delete t/doctor i/D001`
 
-### Updating an existing doctor: `update t/doctor`
+### Updating an existing doctor: `edit t/doctor`
 
-Updates a doctor's details from the GoMedic application.
+Edits a doctor's details from the GoMedic application.
 
-Format: `update t/doctor i/DOCTOR_ID [OPTIONAL_PARAMETER]...`
+Format: `edit t/doctor i/DOCTOR_ID [OPTIONAL_PARAMETER]...`
 
 The parameters are:
 * `i/DOCTOR_ID` indicates the ID number of the doctor which is assigned when a new doctor is added.
@@ -462,7 +462,7 @@ Action        | Format, Examples |
 --------------|------------------ |
 **Add**       | `add {type} {PARAMETERS}`<br> e.g., `add t/doctor n/Timmy Tom p/98765432 de/neurology`
 **Delete**    | `delete {type} i/{type}_ID` <br> e.g., `delete t/patient i/P003`<br>
-**Update**    | `update {type} i/{type}_ID [OPTIONAL PARAMETER]...`<br>e.g.,`update t/patient i/P123 n/John Doe a/30 g/M`<br>
+**Edit**      | `edit {type} i/{type}_ID [OPTIONAL PARAMETER]...`<br>e.g.,`edit t/patient i/P123 n/John Doe a/30 g/M`<br>
 **Find**      | `find [OPTIONAL_PARAMATERS]...`<br> e.g., `find ta/important ti/tutorial`<br>
 **View**      | `view t/doctor i/DOCTOR_ID`, `view t/patient i/PATIENT_ID`<br> e.g., `view t/patient i/P003`
 **Tag**       | `tag t/activity  i/ACTIVITY_ID [ta/TAG_DESCRIPTION]...` <br> e.g., `tag t/activity i/A420 ta/important ta/NUS ta/schoolwork`

--- a/src/main/java/gomedic/logic/commands/addcommand/AddActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/addcommand/AddActivityCommand.java
@@ -4,6 +4,7 @@ import static gomedic.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static gomedic.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static gomedic.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static gomedic.logic.parser.CliSyntax.PREFIX_TITLE;
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_ACTIVITY;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
 
@@ -23,7 +24,7 @@ import gomedic.model.commonfield.Time;
  * Adds an activity to the address book
  */
 public class AddActivityCommand extends Command {
-    public static final String COMMAND_WORD = "add t/activity";
+    public static final String COMMAND_WORD = "add" + " " + PREFIX_TYPE_ACTIVITY;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an activity to the address book. "
             + "Parameters: "

--- a/src/main/java/gomedic/logic/commands/addcommand/AddDoctorCommand.java
+++ b/src/main/java/gomedic/logic/commands/addcommand/AddDoctorCommand.java
@@ -3,6 +3,7 @@ package gomedic.logic.commands.addcommand;
 import static gomedic.logic.parser.CliSyntax.PREFIX_DEPARTMENT;
 import static gomedic.logic.parser.CliSyntax.PREFIX_NAME;
 import static gomedic.logic.parser.CliSyntax.PREFIX_PHONE;
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_DOCTOR;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
 
@@ -23,7 +24,7 @@ import gomedic.model.person.doctor.DoctorId;
  * Adds an doctor to the address book
  */
 public class AddDoctorCommand extends Command {
-    public static final String COMMAND_WORD = "add t/doctor";
+    public static final String COMMAND_WORD = "add" + " " + PREFIX_TYPE_DOCTOR;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a doctor to the address book. "
             + "Parameters: "

--- a/src/main/java/gomedic/logic/commands/addcommand/AddPatientCommand.java
+++ b/src/main/java/gomedic/logic/commands/addcommand/AddPatientCommand.java
@@ -7,6 +7,7 @@ import static gomedic.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static gomedic.logic.parser.CliSyntax.PREFIX_MEDICALCONDITIONS;
 import static gomedic.logic.parser.CliSyntax.PREFIX_NAME;
 import static gomedic.logic.parser.CliSyntax.PREFIX_PHONE;
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_PATIENT;
 import static gomedic.logic.parser.CliSyntax.PREFIX_WEIGHT;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
@@ -35,7 +36,7 @@ import gomedic.model.tag.Tag;
  * Adds a patient to the address book
  */
 public class AddPatientCommand extends Command {
-    public static final String COMMAND_WORD = "add t/patient";
+    public static final String COMMAND_WORD = "add" + " " + PREFIX_TYPE_PATIENT;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to the address book. "
             + "Parameters: "

--- a/src/main/java/gomedic/logic/commands/clearcommand/ClearActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/clearcommand/ClearActivityCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.clearcommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_ACTIVITY;
 import static java.util.Objects.requireNonNull;
 
 import gomedic.logic.commands.Command;
@@ -13,7 +14,7 @@ import gomedic.model.ReadOnlyAddressBook;
  */
 public class ClearActivityCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear t/activity";
+    public static final String COMMAND_WORD = "clear" + " " + PREFIX_TYPE_ACTIVITY;
     public static final String MESSAGE_SUCCESS = "activities in GoMedic has been cleared!";
 
 

--- a/src/main/java/gomedic/logic/commands/clearcommand/ClearDoctorCommand.java
+++ b/src/main/java/gomedic/logic/commands/clearcommand/ClearDoctorCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.clearcommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_DOCTOR;
 import static java.util.Objects.requireNonNull;
 
 import gomedic.logic.commands.Command;
@@ -13,7 +14,7 @@ import gomedic.model.ReadOnlyAddressBook;
  */
 public class ClearDoctorCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear t/doctor";
+    public static final String COMMAND_WORD = "clear" + " " + PREFIX_TYPE_DOCTOR;
     public static final String MESSAGE_SUCCESS = "doctors in GoMedic has been cleared!";
 
 

--- a/src/main/java/gomedic/logic/commands/clearcommand/ClearPatientCommand.java
+++ b/src/main/java/gomedic/logic/commands/clearcommand/ClearPatientCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.clearcommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_PATIENT;
 import static java.util.Objects.requireNonNull;
 
 import gomedic.logic.commands.Command;
@@ -13,7 +14,7 @@ import gomedic.model.ReadOnlyAddressBook;
  */
 public class ClearPatientCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear t/patient";
+    public static final String COMMAND_WORD = "clear" + " " + PREFIX_TYPE_PATIENT;
     public static final String MESSAGE_SUCCESS = "patients in GoMedic has been cleared!";
 
 

--- a/src/main/java/gomedic/logic/commands/deletecommand/DeleteActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/deletecommand/DeleteActivityCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.deletecommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_ACTIVITY;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -17,7 +18,7 @@ import gomedic.model.commonfield.Id;
  */
 public class DeleteActivityCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete t/activity";
+    public static final String COMMAND_WORD = "delete" + " " + PREFIX_TYPE_ACTIVITY;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the activity identified by the index shown in the activity list.\n"

--- a/src/main/java/gomedic/logic/commands/deletecommand/DeleteDoctorCommand.java
+++ b/src/main/java/gomedic/logic/commands/deletecommand/DeleteDoctorCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.deletecommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_DOCTOR;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -16,7 +17,7 @@ import gomedic.model.person.doctor.Doctor;
  * Deletes a doctor identified using it's displayed index from the address book.
  */
 public class DeleteDoctorCommand extends Command {
-    public static final String COMMAND_WORD = "delete t/doctor";
+    public static final String COMMAND_WORD = "delete" + " " + PREFIX_TYPE_DOCTOR;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the doctor identified by the index shown in the doctor list.\n"

--- a/src/main/java/gomedic/logic/commands/deletecommand/DeletePatientCommand.java
+++ b/src/main/java/gomedic/logic/commands/deletecommand/DeletePatientCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.deletecommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_PATIENT;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -17,7 +18,7 @@ import gomedic.model.person.patient.Patient;
  */
 public class DeletePatientCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete t/patient";
+    public static final String COMMAND_WORD = "delete" + " " + PREFIX_TYPE_PATIENT;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Deletes the patient identified by the index shown in the patient list.\n"

--- a/src/main/java/gomedic/logic/commands/editcommand/EditDoctorCommand.java
+++ b/src/main/java/gomedic/logic/commands/editcommand/EditDoctorCommand.java
@@ -4,6 +4,7 @@ import static gomedic.logic.parser.CliSyntax.PREFIX_DEPARTMENT;
 import static gomedic.logic.parser.CliSyntax.PREFIX_ID;
 import static gomedic.logic.parser.CliSyntax.PREFIX_NAME;
 import static gomedic.logic.parser.CliSyntax.PREFIX_PHONE;
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_DOCTOR;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
 
@@ -29,7 +30,7 @@ import gomedic.model.person.doctor.DoctorId;
  */
 public class EditDoctorCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit t/doctor";
+    public static final String COMMAND_WORD = "edit" + " " + PREFIX_TYPE_DOCTOR;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the doctor identified "
             + "by the index number used in the displayed doctor list. "
@@ -38,7 +39,7 @@ public class EditDoctorCommand extends Command {
             + "[" + PREFIX_ID + "ID] "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_DEPARTMENT + "EMAIL] "
+            + "[" + PREFIX_DEPARTMENT + "DEPARTMENT] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_ID + " D001 "
             + PREFIX_NAME + "John Snow "
@@ -85,9 +86,7 @@ public class EditDoctorCommand extends Command {
 
         Doctor doctorToEdit = lastShownList
                 .stream()
-                .filter(doctor -> doctor
-                        .getId()
-                        .toString().equals(targetId.toString()))
+                .filter(doctor -> doctor.getId().toString().equals(targetId.toString()))
                 .findFirst()
                 .orElse(null);
 

--- a/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.listcommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_ACTIVITY;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
 
@@ -13,7 +14,7 @@ import gomedic.model.ModelItem;
  */
 public class ListActivityCommand extends Command {
 
-    public static final String COMMAND_WORD = "list t/activity";
+    public static final String COMMAND_WORD = "list" + " " + PREFIX_TYPE_ACTIVITY;
 
     public static final String MESSAGE_SUCCESS = "Listed all activities sorted by id";
 

--- a/src/main/java/gomedic/logic/commands/listcommand/ListDoctorCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListDoctorCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.listcommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_DOCTOR;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
 
@@ -9,7 +10,7 @@ import gomedic.model.Model;
 import gomedic.model.ModelItem;
 
 public class ListDoctorCommand extends Command {
-    public static final String COMMAND_WORD = "list t/doctor";
+    public static final String COMMAND_WORD = "list" + " " + PREFIX_TYPE_DOCTOR;
 
     public static final String MESSAGE_SUCCESS = "Listed all doctor sorted by id";
 

--- a/src/main/java/gomedic/logic/commands/listcommand/ListPatientCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListPatientCommand.java
@@ -1,5 +1,6 @@
 package gomedic.logic.commands.listcommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_PATIENT;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
 
@@ -9,7 +10,7 @@ import gomedic.model.Model;
 import gomedic.model.ModelItem;
 
 public class ListPatientCommand extends Command {
-    public static final String COMMAND_WORD = "list t/patient";
+    public static final String COMMAND_WORD = "list" + " " + PREFIX_TYPE_PATIENT;
 
     public static final String MESSAGE_SUCCESS = "Listed all patients sorted by id";
 

--- a/src/main/java/gomedic/logic/parser/CliSyntax.java
+++ b/src/main/java/gomedic/logic/parser/CliSyntax.java
@@ -4,6 +4,12 @@ package gomedic.logic.parser;
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
 public class CliSyntax {
+    /* Prefixes for entry types */
+    public static final String PREFIX_TYPE_AS_STRING = "t/";
+    public static final Prefix PREFIX_TYPE = new Prefix(PREFIX_TYPE_AS_STRING);
+    public static final String PREFIX_TYPE_DOCTOR = PREFIX_TYPE_AS_STRING + "doctor";
+    public static final String PREFIX_TYPE_ACTIVITY = PREFIX_TYPE_AS_STRING + "activity";
+    public static final String PREFIX_TYPE_PATIENT = PREFIX_TYPE_AS_STRING + "patient";
 
     /* General prefixes */
     public static final Prefix PREFIX_NAME = new Prefix("n/");


### PR DESCRIPTION
### Summary

- Abstract out some shared variables for more reusability 

### Detail

One of the grading requirements is the amount of code duplication in the code base, so I have done some minor updates to reduce some code duplication for the command words; We should do another major check through and refactoring after this

![image](https://user-images.githubusercontent.com/48285332/137264594-52333465-e984-4940-a901-c61c5f3d487f.png)

Possible things to look at:
- Let each command extend an `abstract` class of it; e.g `AddDoctorCommand extends AddCommand`, where `AddCommand` is an abstract class that defines common attributes like the base command word (`add`)

### Pictures / Gif

![image](https://user-images.githubusercontent.com/48285332/137264938-253224dc-1af9-4af5-9779-17069ef19fc7.png)
_Commonly shared variables for the command words are defined here_

![image](https://user-images.githubusercontent.com/48285332/137265003-620dc734-3cf2-46fc-b26f-0201664d9d2d.png)
_The new command word declarations will look like this_

### Checks

- [X] Add Reviewer
- [ ] Pass CI
