### PR TITLE
Add sorting by start time and show within certain period for activities

### DIFF
--- a/src/main/java/gomedic/logic/Logic.java
+++ b/src/main/java/gomedic/logic/Logic.java
@@ -41,8 +41,11 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of doctors */
     ObservableList<Doctor> getFilteredDoctorList();
 
-    /** Returns an unmodifiable view of the filtered list of activities */
-    ObservableList<Activity> getFilteredActivityList();
+    /** Returns an unmodifiable view of the filtered list of activities sorted by id*/
+    ObservableList<Activity> getFilteredActivityListById();
+
+    /** Returns an unmodifiable view of the filtered list of activities sorted by start time*/
+    ObservableList<Activity> getFilteredActivityListByStartTime();
 
     /**
      * Returns the user prefs' address root file path.

--- a/src/main/java/gomedic/logic/LogicManager.java
+++ b/src/main/java/gomedic/logic/LogicManager.java
@@ -74,8 +74,13 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Activity> getFilteredActivityList() {
-        return model.getFilteredActivityList();
+    public ObservableList<Activity> getFilteredActivityListById() {
+        return model.getFilteredActivityListById();
+    }
+
+    @Override
+    public ObservableList<Activity> getFilteredActivityListByStartTime() {
+        return model.getFilteredActivityListByStartTime();
     }
 
     @Override

--- a/src/main/java/gomedic/logic/commands/addcommand/AddActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/addcommand/AddActivityCommand.java
@@ -83,7 +83,7 @@ public class AddActivityCommand extends Command {
         }
 
         model.addActivity(toAdd);
-        model.setModelBeingShown(ModelItem.ACTIVITY);
+        model.setModelBeingShown(ModelItem.ACTIVITY_ID);
         model.updateFilteredActivitiesList(PREDICATE_SHOW_ALL_ITEMS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/gomedic/logic/commands/deletecommand/DeleteActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/deletecommand/DeleteActivityCommand.java
@@ -36,7 +36,7 @@ public class DeleteActivityCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Activity> lastShownList = model.getFilteredActivityList();
+        List<Activity> lastShownList = model.getFilteredActivityListById();
 
         Activity activityToDelete = lastShownList
                 .stream()

--- a/src/main/java/gomedic/logic/commands/editcommand/EditActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/editcommand/EditActivityCommand.java
@@ -112,8 +112,8 @@ public class EditActivityCommand extends Command {
 
         model.setActivity(activityToEdit, editedActivity);
         model.updateFilteredActivitiesList(PREDICATE_SHOW_ALL_ITEMS);
-        if (!(model.getModelBeingShown().getValue().equals(ModelItem.ACTIVITY_ID.ordinal()) ||
-                model.getModelBeingShown().getValue().equals(ModelItem.ACTIVITY_START_TIME.ordinal()))) {
+        if (!(model.getModelBeingShown().getValue().equals(ModelItem.ACTIVITY_ID.ordinal())
+                || model.getModelBeingShown().getValue().equals(ModelItem.ACTIVITY_START_TIME.ordinal()))) {
             model.setModelBeingShown(ModelItem.ACTIVITY_ID);
         }
 

--- a/src/main/java/gomedic/logic/commands/editcommand/EditActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/editcommand/EditActivityCommand.java
@@ -86,7 +86,7 @@ public class EditActivityCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Activity> lastShownList = model.getFilteredActivityList();
+        List<Activity> lastShownList = model.getFilteredActivityListById();
 
         Activity activityToEdit = lastShownList
                 .stream()
@@ -101,7 +101,7 @@ public class EditActivityCommand extends Command {
         Activity editedActivity = createEditedActivity(activityToEdit, editActivityDescriptor);
 
         boolean anyConflicting = model
-                .getFilteredActivityList()
+                .getFilteredActivityListById()
                 .stream()
                 .anyMatch(it -> it.isConflicting(editedActivity) && !it.getActivityId()
                         .equals(editedActivity.getActivityId()));
@@ -112,7 +112,10 @@ public class EditActivityCommand extends Command {
 
         model.setActivity(activityToEdit, editedActivity);
         model.updateFilteredActivitiesList(PREDICATE_SHOW_ALL_ITEMS);
-        model.setModelBeingShown(ModelItem.ACTIVITY);
+        if (!(model.getModelBeingShown().getValue().equals(ModelItem.ACTIVITY_ID.ordinal()) ||
+                model.getModelBeingShown().getValue().equals(ModelItem.ACTIVITY_START_TIME.ordinal()))) {
+            model.setModelBeingShown(ModelItem.ACTIVITY_ID);
+        }
 
         return new CommandResult(String.format(MESSAGE_EDIT_ACTIVITY_SUCCESS, editedActivity));
     }

--- a/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
@@ -50,7 +50,6 @@ public class ListActivityCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        System.out.println("test");
         switch (sortFlag) {
         case ID:
             model.setModelBeingShown(ModelItem.ACTIVITY_ID);

--- a/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
@@ -36,6 +36,12 @@ public class ListActivityCommand extends Command {
     private final Sort sortFlag;
     private final Period periodFlag;
 
+    /**
+     * Constructs a new list activity command.
+     *
+     * @param sortFlag to be sorted by id or start time.
+     * @param periodFlag to show all, today, within one week, etc.
+     */
     public ListActivityCommand(Sort sortFlag, Period periodFlag) {
         this.sortFlag = sortFlag;
         this.periodFlag = periodFlag;
@@ -52,6 +58,8 @@ public class ListActivityCommand extends Command {
         case START:
             model.setModelBeingShown(ModelItem.ACTIVITY_START_TIME);
             break;
+        default:
+            break;
         }
 
         Time yesterday = new Time(LocalDateTime.now().minusDays(1));
@@ -67,6 +75,7 @@ public class ListActivityCommand extends Command {
         case WEEK:
             model.updateFilteredActivitiesList(activity ->
                     isInBetween(activity, yesterday, new Time(LocalDateTime.now().plusDays(7))));
+            break;
         case MONTH:
             model.updateFilteredActivitiesList(activity ->
                     isInBetween(activity, yesterday, new Time(LocalDateTime.now().plusMonths(1))));
@@ -74,6 +83,8 @@ public class ListActivityCommand extends Command {
         case YEAR:
             model.updateFilteredActivitiesList(activity ->
                     isInBetween(activity, yesterday, new Time(LocalDateTime.now().plusYears(1))));
+            break;
+        default:
             break;
         }
 

--- a/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
+++ b/src/main/java/gomedic/logic/commands/listcommand/ListActivityCommand.java
@@ -1,13 +1,19 @@
 package gomedic.logic.commands.listcommand;
 
+import static gomedic.logic.parser.CliSyntax.PREFIX_PERIOD_FLAG;
+import static gomedic.logic.parser.CliSyntax.PREFIX_SORT_FLAG;
 import static gomedic.logic.parser.CliSyntax.PREFIX_TYPE_ACTIVITY;
 import static gomedic.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 import static java.util.Objects.requireNonNull;
+
+import java.time.LocalDateTime;
 
 import gomedic.logic.commands.Command;
 import gomedic.logic.commands.CommandResult;
 import gomedic.model.Model;
 import gomedic.model.ModelItem;
+import gomedic.model.activity.Activity;
+import gomedic.model.commonfield.Time;
 
 /**
  * Lists all activities in the address book to the user.
@@ -16,13 +22,110 @@ public class ListActivityCommand extends Command {
 
     public static final String COMMAND_WORD = "list" + " " + PREFIX_TYPE_ACTIVITY;
 
-    public static final String MESSAGE_SUCCESS = "Listed all activities sorted by id";
+    public static final String MESSAGE_SUCCESS = "Listed all activities according the flags!";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": List all the activities based on the flag "
+            + "by default, all existing activities sorted by id would be shown!\n"
+            + "Parameters: "
+            + "[" + PREFIX_SORT_FLAG + "SORT_FLAG] "
+            + "[" + PREFIX_PERIOD_FLAG + "PERIOD] "
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_SORT_FLAG + "START "
+            + PREFIX_PERIOD_FLAG + "TODAY ";
+
+    private final Sort sortFlag;
+    private final Period periodFlag;
+
+    public ListActivityCommand(Sort sortFlag, Period periodFlag) {
+        this.sortFlag = sortFlag;
+        this.periodFlag = periodFlag;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setModelBeingShown(ModelItem.ACTIVITY);
-        model.updateFilteredActivitiesList(PREDICATE_SHOW_ALL_ITEMS);
+        System.out.println("test");
+        switch (sortFlag) {
+        case ID:
+            model.setModelBeingShown(ModelItem.ACTIVITY_ID);
+            break;
+        case START:
+            model.setModelBeingShown(ModelItem.ACTIVITY_START_TIME);
+            break;
+        }
+
+        Time yesterday = new Time(LocalDateTime.now().minusDays(1));
+
+        switch (periodFlag) {
+        case ALL:
+            model.updateFilteredActivitiesList(PREDICATE_SHOW_ALL_ITEMS);
+            break;
+        case TODAY:
+            model.updateFilteredActivitiesList(activity ->
+                    isInBetween(activity, yesterday, new Time(LocalDateTime.now().plusDays(1))));
+            break;
+        case WEEK:
+            model.updateFilteredActivitiesList(activity ->
+                    isInBetween(activity, yesterday, new Time(LocalDateTime.now().plusDays(7))));
+        case MONTH:
+            model.updateFilteredActivitiesList(activity ->
+                    isInBetween(activity, yesterday, new Time(LocalDateTime.now().plusMonths(1))));
+            break;
+        case YEAR:
+            model.updateFilteredActivitiesList(activity ->
+                    isInBetween(activity, yesterday, new Time(LocalDateTime.now().plusYears(1))));
+            break;
+        }
+
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    // start and end are exclusive
+    private boolean isInBetween(Activity activity, Time start, Time end) {
+        return activity.getStartTime().isAfter(start) && activity.getStartTime().isBefore(end);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ListActivityCommand)) {
+            return false;
+        }
+
+        // state check
+        ListActivityCommand e = (ListActivityCommand) other;
+        return sortFlag.equals(e.sortFlag)
+                && periodFlag.equals(e.periodFlag);
+    }
+
+    /**
+     * Sorting flags that are available for this command.
+     */
+    public enum Sort {
+        ID,
+        START;
+
+        public static final String MESSAGE_CONSTRAINTS =
+                "The flag must be either ID (default) or START to sort by start time";
+    }
+
+    /**
+     * Activity listing flags that will show all future activities within the stipulated period.
+     * Today means present, Week means one week from today until next week and so on and so forth.
+     */
+    public enum Period {
+        ALL,
+        TODAY,
+        WEEK,
+        MONTH,
+        YEAR;
+
+        public static final String MESSAGE_CONSTRAINTS =
+                "The flag must be either ALL (Default), TODAY, WEEK, MONTH, or YEAR ";
     }
 }

--- a/src/main/java/gomedic/logic/parser/AddressBookParser.java
+++ b/src/main/java/gomedic/logic/parser/AddressBookParser.java
@@ -34,6 +34,7 @@ import gomedic.logic.parser.editcommandparser.EditActivityCommandParser;
 import gomedic.logic.parser.editcommandparser.EditDoctorCommandParser;
 import gomedic.logic.parser.editcommandparser.EditPatientCommandParser;
 import gomedic.logic.parser.exceptions.ParseException;
+import gomedic.logic.parser.listcommandparser.ListActivityParser;
 
 /**
  * Parses user input.
@@ -120,7 +121,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListActivityCommand.COMMAND_WORD:
-            return new ListActivityCommand();
+            return new ListActivityParser().parse(arguments);
 
         case ListDoctorCommand.COMMAND_WORD:
             return new ListDoctorCommand();

--- a/src/main/java/gomedic/logic/parser/CliSyntax.java
+++ b/src/main/java/gomedic/logic/parser/CliSyntax.java
@@ -32,4 +32,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_START_TIME = new Prefix("s/");
     public static final Prefix PREFIX_END_TIME = new Prefix("e/");
+
+    /* Prefix definitions for listing */
+    public static final Prefix PREFIX_SORT_FLAG = new Prefix("s/");
+    public static final Prefix PREFIX_PERIOD_FLAG = new Prefix("p/");
 }

--- a/src/main/java/gomedic/logic/parser/ParserUtil.java
+++ b/src/main/java/gomedic/logic/parser/ParserUtil.java
@@ -2,12 +2,15 @@ package gomedic.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import gomedic.commons.core.index.Index;
 import gomedic.commons.util.StringUtil;
+import gomedic.logic.commands.listcommand.ListActivityCommand;
 import gomedic.logic.parser.exceptions.ParseException;
 import gomedic.model.activity.ActivityId;
 import gomedic.model.activity.Description;
@@ -273,5 +276,37 @@ public class ParserUtil {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
         return new Tag(trimmedTag);
+    }
+
+    /**
+     * Parses a {@code String sortFlag} into a {@code Sort} flag.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code sortFlag} is invalid.
+     */
+    public static ListActivityCommand.Sort parseSortActivityFlags(String sortFlag) throws ParseException {
+        requireNonNull(sortFlag);
+        String trimmedSortFlag = sortFlag.trim();
+        if (Arrays.stream(ListActivityCommand.Sort.values())
+                .noneMatch(it -> it.toString().equalsIgnoreCase(trimmedSortFlag))) {
+            throw new ParseException(ListActivityCommand.Sort.MESSAGE_CONSTRAINTS);
+        }
+        return ListActivityCommand.Sort.valueOf(sortFlag.toUpperCase());
+    }
+
+    /**
+     * Parses a {@code String sortFlag} into a {@code Sort} flag.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code sortFlag} is invalid.
+     */
+    public static ListActivityCommand.Period parsePeriodActivityFlags(String periodFlag) throws ParseException {
+        requireNonNull(periodFlag);
+        String trimmedPeriodFlag = periodFlag.trim();
+        if (Arrays.stream(ListActivityCommand.Period.values())
+                .noneMatch(it -> it.toString().equalsIgnoreCase(trimmedPeriodFlag))) {
+            throw new ParseException(ListActivityCommand.Period.MESSAGE_CONSTRAINTS);
+        }
+        return ListActivityCommand.Period.valueOf(periodFlag.toUpperCase());
     }
 }

--- a/src/main/java/gomedic/logic/parser/ParserUtil.java
+++ b/src/main/java/gomedic/logic/parser/ParserUtil.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 
 import gomedic.commons.core.index.Index;

--- a/src/main/java/gomedic/logic/parser/listcommandparser/ListActivityParser.java
+++ b/src/main/java/gomedic/logic/parser/listcommandparser/ListActivityParser.java
@@ -9,7 +9,7 @@ import gomedic.logic.parser.ParserUtil;
 import gomedic.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeleteActivityCommand object
+ * Parses input arguments and creates a new ListActivityCommand object.
  */
 public class ListActivityParser implements Parser<ListActivityCommand> {
 

--- a/src/main/java/gomedic/logic/parser/listcommandparser/ListActivityParser.java
+++ b/src/main/java/gomedic/logic/parser/listcommandparser/ListActivityParser.java
@@ -1,0 +1,58 @@
+package gomedic.logic.parser.listcommandparser;
+
+import gomedic.logic.commands.listcommand.ListActivityCommand;
+import gomedic.logic.parser.ArgumentMultimap;
+import gomedic.logic.parser.ArgumentTokenizer;
+import gomedic.logic.parser.CliSyntax;
+import gomedic.logic.parser.Parser;
+import gomedic.logic.parser.ParserUtil;
+import gomedic.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteActivityCommand object
+ */
+public class ListActivityParser implements Parser<ListActivityCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListActivityCommand
+     * and returns a ListActivityCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListActivityCommand parse(String args) throws ParseException {
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args,
+                        CliSyntax.PREFIX_SORT_FLAG,
+                        CliSyntax.PREFIX_PERIOD_FLAG);
+
+        ListActivityCommand.Sort sortFlag = ListActivityCommand.Sort.ID;
+        ListActivityCommand.Period periodFlag = ListActivityCommand.Period.ALL;
+
+        try {
+            if (argMultimap.getValue(CliSyntax.PREFIX_SORT_FLAG).isPresent()) {
+                sortFlag = ParserUtil
+                        .parseSortActivityFlags(argMultimap.getValue(CliSyntax.PREFIX_SORT_FLAG).get());
+            }
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    ListActivityCommand.Sort.MESSAGE_CONSTRAINTS
+                            + "\n"
+                            + ListActivityCommand.MESSAGE_USAGE);
+        }
+
+        try {
+            if (argMultimap.getValue(CliSyntax.PREFIX_PERIOD_FLAG).isPresent()) {
+                periodFlag = ParserUtil
+                        .parsePeriodActivityFlags(argMultimap.getValue(CliSyntax.PREFIX_PERIOD_FLAG).get());
+            }
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    ListActivityCommand.Period.MESSAGE_CONSTRAINTS
+                            + "\n"
+                            + ListActivityCommand.MESSAGE_USAGE);
+        }
+
+        return new ListActivityCommand(sortFlag, periodFlag);
+    }
+}

--- a/src/main/java/gomedic/model/AddressBook.java
+++ b/src/main/java/gomedic/model/AddressBook.java
@@ -273,7 +273,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public ObservableList<Activity> getActivityListSortedStartTime() {
+    public ObservableList<Activity> getActivityListSortedByStartTime() {
         return activities.asUnmodifiableSortedByStartTimeList();
     }
 

--- a/src/main/java/gomedic/model/Model.java
+++ b/src/main/java/gomedic/model/Model.java
@@ -161,8 +161,11 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered patient list */
     ObservableList<Patient> getFilteredPatientList();
 
-    /** Returns an unmodifiable view of the filtered activity list */
-    ObservableList<Activity> getFilteredActivityList();
+    /** Returns an unmodifiable view of the filtered activity list sorted by id*/
+    ObservableList<Activity> getFilteredActivityListById();
+
+    /** Returns an unmodifiable view of the filtered activity list sorted by start time*/
+    ObservableList<Activity> getFilteredActivityListByStartTime();
 
     /**
      * Updates the filter of the filtered doctor list to filter by the given {@code predicate}.

--- a/src/main/java/gomedic/model/ModelItem.java
+++ b/src/main/java/gomedic/model/ModelItem.java
@@ -1,7 +1,8 @@
 package gomedic.model;
 
 public enum ModelItem {
-    ACTIVITY,
+    ACTIVITY_ID,
+    ACTIVITY_START_TIME,
     DOCTOR,
     PATIENT
 }

--- a/src/main/java/gomedic/model/ModelManager.java
+++ b/src/main/java/gomedic/model/ModelManager.java
@@ -28,13 +28,12 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Doctor> filteredDoctors;
     private final FilteredList<Patient> filteredPatients;
-    private final FilteredList<Activity> filteredActivities;
-
     // used the ordinal value 0 -> Activity, 1 -> Doctor, 2 -> Patient, for simplicity.
     private final ObjectProperty<Integer> internalModelItemBeingShown =
-            new SimpleIntegerProperty(ModelItem.ACTIVITY.ordinal()).asObject();
-
+            new SimpleIntegerProperty(ModelItem.ACTIVITY_ID.ordinal()).asObject();
     private final ObservableValue<Integer> modelItemBeingShown = internalModelItemBeingShown; // immutable
+    private final FilteredList<Activity> filteredActivitiesById;
+    private final FilteredList<Activity> filteredActivitiesByStartTime;
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
@@ -53,7 +52,8 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredDoctors = new FilteredList<>(this.addressBook.getDoctorListSortedById());
         filteredPatients = new FilteredList<>(this.addressBook.getPatientListSortedById());
-        filteredActivities = new FilteredList<>(this.addressBook.getActivityListSortedById());
+        filteredActivitiesById = new FilteredList<>(this.addressBook.getActivityListSortedById());
+        filteredActivitiesByStartTime = new FilteredList<>(this.addressBook.getActivityListSortedByStartTime());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -122,7 +122,8 @@ public class ModelManager implements Model {
     @Override
     public void updateFilteredActivitiesList(Predicate<? super Activity> predicate) {
         requireNonNull(predicate);
-        filteredActivities.setPredicate(predicate);
+        filteredActivitiesById.setPredicate(predicate);
+        filteredActivitiesByStartTime.setPredicate(predicate);
     }
 
     @Override
@@ -196,12 +197,7 @@ public class ModelManager implements Model {
     public void addActivity(Activity activity) {
         requireNonNull(activity);
         addressBook.addActivity(activity);
-        updateFilteredActivityList(PREDICATE_SHOW_ALL_ITEMS);
-    }
-
-    private void updateFilteredActivityList(Predicate<? super Activity> predicate) {
-        requireNonNull(predicate);
-        filteredActivities.setPredicate(predicate);
+        updateFilteredActivitiesList(PREDICATE_SHOW_ALL_ITEMS);
     }
 
     @Override
@@ -266,8 +262,13 @@ public class ModelManager implements Model {
      * {@code versionedAddressBook}
      */
     @Override
-    public ObservableList<Activity> getFilteredActivityList() {
-        return filteredActivities;
+    public ObservableList<Activity> getFilteredActivityListById() {
+        return filteredActivitiesById;
+    }
+
+    @Override
+    public ObservableList<Activity> getFilteredActivityListByStartTime() {
+        return filteredActivitiesByStartTime;
     }
 
     @Override
@@ -288,7 +289,8 @@ public class ModelManager implements Model {
                 && userPrefs.equals(other.userPrefs)
                 && filteredDoctors.equals(other.filteredDoctors)
                 && filteredPatients.equals(other.filteredPatients)
-                && filteredActivities.equals(other.filteredActivities);
+                && filteredActivitiesById.equals(other.filteredActivitiesById)
+                && filteredActivitiesByStartTime.equals(other.filteredActivitiesByStartTime);
     }
 
 }

--- a/src/main/java/gomedic/model/ReadOnlyAddressBook.java
+++ b/src/main/java/gomedic/model/ReadOnlyAddressBook.java
@@ -32,5 +32,5 @@ public interface ReadOnlyAddressBook {
      * Returns a sorted list by start time.
      * Guarantee: This list will not contain any conflicting and duplicate activity.
      */
-    ObservableList<Activity> getActivityListSortedStartTime();
+    ObservableList<Activity> getActivityListSortedByStartTime();
 }

--- a/src/main/java/gomedic/ui/MainWindow.java
+++ b/src/main/java/gomedic/ui/MainWindow.java
@@ -82,12 +82,17 @@ public class MainWindow extends UiPart<Stage> {
             modelListPanelPlaceholder.getChildren().clear();
             switch (newVal) {
             case 0:
+                activityTable = new ActivityTable(logic.getFilteredActivityListById());
                 modelListPanelPlaceholder.getChildren().add(activityTable.getRoot());
                 break;
             case 1:
-                modelListPanelPlaceholder.getChildren().add(doctorListPanel.getRoot());
+                activityTable = new ActivityTable(logic.getFilteredActivityListByStartTime());
+                modelListPanelPlaceholder.getChildren().add(activityTable.getRoot());
                 break;
             case 2:
+                modelListPanelPlaceholder.getChildren().add(doctorListPanel.getRoot());
+                break;
+            case 3:
                 modelListPanelPlaceholder.getChildren().add(patientListPanel.getRoot());
                 break;
             default:
@@ -140,7 +145,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        activityTable = new ActivityTable(logic.getFilteredActivityList());
+        activityTable = new ActivityTable(logic.getFilteredActivityListById());
         doctorListPanel = new DoctorListPanel(logic.getFilteredDoctorList());
         patientListPanel = new PatientListPanel(logic.getFilteredPatientList());
 

--- a/src/test/java/gomedic/logic/LogicManagerTest.java
+++ b/src/test/java/gomedic/logic/LogicManagerTest.java
@@ -226,12 +226,12 @@ public class LogicManagerTest {
 
     @Test
     public void getFilteredActivityList_modifyList_throwsUnsupportedOperationException() {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredActivityList().remove(0));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredActivityListById().remove(0));
     }
 
     @Test
     void getModelBeingShown_defaultValue_testPassed() {
-        assertEquals(ModelItem.ACTIVITY.ordinal(), logic.getModelBeingShown().getValue());
+        assertEquals(ModelItem.ACTIVITY_ID.ordinal(), logic.getModelBeingShown().getValue());
     }
 
     @Test

--- a/src/test/java/gomedic/logic/commands/CommandTestUtil.java
+++ b/src/test/java/gomedic/logic/commands/CommandTestUtil.java
@@ -95,6 +95,15 @@ public class CommandTestUtil {
     public static final String INVALID_DESC_MEDICALCONDITIONS_MAIN_PATIENT = " " + CliSyntax.PREFIX_MEDICALCONDITIONS
             + "invalid**";
 
+    /* for listing activities */
+    public static final String VALID_PERIOD_FLAG_TODAY = " " + CliSyntax.PREFIX_PERIOD_FLAG + "TODAY";
+    public static final String VALID_PERIOD_FLAG_ALL = " " + CliSyntax.PREFIX_PERIOD_FLAG + "ALL";
+    public static final String VALID_SORT_FLAG_START = " " + CliSyntax.PREFIX_SORT_FLAG + "START";
+    public static final String VALID_SORT_FLAG_ID = " " + CliSyntax.PREFIX_SORT_FLAG + "ID";
+
+    public static final String INVALID_PERIOD_FLAG = " " + CliSyntax.PREFIX_PERIOD_FLAG + "TOMORROW";
+    public static final String INVALID_SORT_FLAG = " " + CliSyntax.PREFIX_SORT_FLAG + "end time";
+
     /* valid constants declarations for activity related fields */
     public static final String VALID_DESC_TITLE_MEETING =
             " " + CliSyntax.PREFIX_TITLE + "Meeting me";
@@ -147,22 +156,22 @@ public class CommandTestUtil {
                 .withPhone(TypicalPersons.OTHER_DOCTOR.getPhone().value)
                 .withDepartment(TypicalPersons.OTHER_DOCTOR.getDepartment().departmentName).build();
         DESC_MAIN_PATIENT = new EditPatientDescriptorBuilder().withName(TypicalPersons.MAIN_PATIENT.getName().fullName)
-            .withPhone(TypicalPersons.MAIN_PATIENT.getPhone().value)
-            .withAge(TypicalPersons.MAIN_PATIENT.getAge().age)
-            .withBloodType(TypicalPersons.MAIN_PATIENT.getBloodType().bloodType)
-            .withGender(TypicalPersons.MAIN_PATIENT.getGender().gender)
-            .withHeight(TypicalPersons.MAIN_PATIENT.getHeight().height)
-            .withWeight(TypicalPersons.MAIN_PATIENT.getWeight().weight)
-            .withMedicalConditions("heart failure").build();
+                .withPhone(TypicalPersons.MAIN_PATIENT.getPhone().value)
+                .withAge(TypicalPersons.MAIN_PATIENT.getAge().age)
+                .withBloodType(TypicalPersons.MAIN_PATIENT.getBloodType().bloodType)
+                .withGender(TypicalPersons.MAIN_PATIENT.getGender().gender)
+                .withHeight(TypicalPersons.MAIN_PATIENT.getHeight().height)
+                .withWeight(TypicalPersons.MAIN_PATIENT.getWeight().weight)
+                .withMedicalConditions("heart failure").build();
         DESC_OTHER_PATIENT = new EditPatientDescriptorBuilder()
-            .withName(TypicalPersons.OTHER_PATIENT.getName().fullName)
-            .withPhone(TypicalPersons.OTHER_PATIENT.getPhone().value)
-            .withAge(TypicalPersons.OTHER_PATIENT.getAge().age)
-            .withBloodType(TypicalPersons.OTHER_PATIENT.getBloodType().bloodType)
-            .withGender(TypicalPersons.OTHER_PATIENT.getGender().gender)
-            .withHeight(TypicalPersons.OTHER_PATIENT.getHeight().height)
-            .withWeight(TypicalPersons.OTHER_PATIENT.getWeight().weight)
-            .withMedicalConditions("heart failure").build();
+                .withName(TypicalPersons.OTHER_PATIENT.getName().fullName)
+                .withPhone(TypicalPersons.OTHER_PATIENT.getPhone().value)
+                .withAge(TypicalPersons.OTHER_PATIENT.getAge().age)
+                .withBloodType(TypicalPersons.OTHER_PATIENT.getBloodType().bloodType)
+                .withGender(TypicalPersons.OTHER_PATIENT.getGender().gender)
+                .withHeight(TypicalPersons.OTHER_PATIENT.getHeight().height)
+                .withWeight(TypicalPersons.OTHER_PATIENT.getWeight().weight)
+                .withMedicalConditions("heart failure").build();
         DESC_MEETING = new EditActivityDescriptorBuilder()
                 .withStartTime(MEETING.getStartTime().toString())
                 .withEndTime(MEETING.getEndTime().toString())
@@ -211,11 +220,11 @@ public class CommandTestUtil {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Activity> expectedFilteredList = new ArrayList<>(actualModel.getFilteredActivityList());
+        List<Activity> expectedFilteredList = new ArrayList<>(actualModel.getFilteredActivityListById());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
-        assertEquals(expectedFilteredList, actualModel.getFilteredActivityList());
+        assertEquals(expectedFilteredList, actualModel.getFilteredActivityListById());
     }
 
     /**
@@ -251,13 +260,13 @@ public class CommandTestUtil {
      * {@code model}'s address book.
      */
     public static void showActivityAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredActivityList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredActivityListById().size());
 
-        Activity activity = model.getFilteredActivityList().get(targetIndex.getZeroBased());
+        Activity activity = model.getFilteredActivityListById().get(targetIndex.getZeroBased());
         final ActivityId aid = activity.getActivityId();
         model.updateFilteredActivitiesList(activity1 -> activity1.getActivityId().equals(aid));
 
-        assertEquals(1, model.getFilteredActivityList().size());
+        assertEquals(1, model.getFilteredActivityListById().size());
     }
 
     /**
@@ -395,7 +404,12 @@ public class CommandTestUtil {
         }
 
         @Override
-        public ObservableList<Activity> getFilteredActivityList() {
+        public ObservableList<Activity> getFilteredActivityListById() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Activity> getFilteredActivityListByStartTime() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/gomedic/logic/commands/deletecommand/DeleteActivityCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/deletecommand/DeleteActivityCommandTest.java
@@ -26,7 +26,7 @@ public class DeleteActivityCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Activity activityToDelete = model.getFilteredActivityList().get(INDEX_FIRST.getZeroBased());
+        Activity activityToDelete = model.getFilteredActivityListById().get(INDEX_FIRST.getZeroBased());
         DeleteActivityCommand deleteActivityCommand = new DeleteActivityCommand(activityToDelete.getActivityId());
 
         String expectedMessage = String.format(DeleteActivityCommand.MESSAGE_DELETE_ACTIVITY_SUCCESS, activityToDelete);
@@ -48,7 +48,7 @@ public class DeleteActivityCommandTest {
     public void execute_validIndexFilteredList_success() {
         CommandTestUtil.showActivityAtIndex(model, INDEX_FIRST);
 
-        Activity activityToDelete = model.getFilteredActivityList().get(INDEX_FIRST.getZeroBased());
+        Activity activityToDelete = model.getFilteredActivityListById().get(INDEX_FIRST.getZeroBased());
         DeleteActivityCommand deleteActivityCommand = new DeleteActivityCommand(activityToDelete.getActivityId());
 
         String expectedMessage = String.format(DeleteActivityCommand.MESSAGE_DELETE_ACTIVITY_SUCCESS, activityToDelete);
@@ -84,6 +84,6 @@ public class DeleteActivityCommandTest {
     private void showNoActivity(Model model) {
         model.updateFilteredActivitiesList(p -> false);
 
-        assertTrue(model.getFilteredActivityList().isEmpty());
+        assertTrue(model.getFilteredActivityListById().isEmpty());
     }
 }

--- a/src/test/java/gomedic/logic/commands/editcommand/EditActivityCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/editcommand/EditActivityCommandTest.java
@@ -50,15 +50,15 @@ public class EditActivityCommandTest {
         String expectedMessage = String.format(EditActivityCommand.MESSAGE_EDIT_ACTIVITY_SUCCESS, editedActivity);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setActivity(model.getFilteredActivityList().get(0), editedActivity);
+        expectedModel.setActivity(model.getFilteredActivityListById().get(0), editedActivity);
 
         assertCommandSuccess(editActivityCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_someConflictingTiming_throwsConflictingTiming() {
-        Index indexLastActivity = Index.fromOneBased(model.getFilteredActivityList().size());
-        Activity lastActivity = model.getFilteredActivityList().get(indexLastActivity.getZeroBased());
+        Index indexLastActivity = Index.fromOneBased(model.getFilteredActivityListById().size());
+        Activity lastActivity = model.getFilteredActivityListById().get(indexLastActivity.getZeroBased());
         Id targetId = lastActivity.getActivityId();
 
         EditActivityCommand.EditActivityDescriptor descriptor = new EditActivityDescriptorBuilder()
@@ -72,7 +72,7 @@ public class EditActivityCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        Activity editedActivity = model.getFilteredActivityList().get(INDEX_FIRST.getZeroBased());
+        Activity editedActivity = model.getFilteredActivityListById().get(INDEX_FIRST.getZeroBased());
         Id targetId = editedActivity.getActivityId();
         EditActivityCommand editActivityCommand =
                 new EditActivityCommand(targetId, new EditActivityCommand.EditActivityDescriptor());
@@ -89,7 +89,7 @@ public class EditActivityCommandTest {
     public void execute_filteredList_success() {
         showActivityAtIndex(model, INDEX_FIRST);
 
-        Activity activityInFilteredList = model.getFilteredActivityList().get(INDEX_FIRST.getZeroBased());
+        Activity activityInFilteredList = model.getFilteredActivityListById().get(INDEX_FIRST.getZeroBased());
         Activity editedActivity = new ActivityBuilder()
                 .withId(activityInFilteredList.getActivityId().getIdNumber())
                 .withTitle(activityInFilteredList.getTitle().toString())
@@ -104,7 +104,7 @@ public class EditActivityCommandTest {
         String expectedMessage = String.format(EditActivityCommand.MESSAGE_EDIT_ACTIVITY_SUCCESS, editedActivity);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setActivity(model.getFilteredActivityList().get(0), editedActivity);
+        expectedModel.setActivity(model.getFilteredActivityListById().get(0), editedActivity);
 
         assertCommandSuccess(editActivityCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/gomedic/logic/commands/listcommand/ListActivityCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/listcommand/ListActivityCommandTest.java
@@ -4,10 +4,13 @@ import static gomedic.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static gomedic.logic.commands.CommandTestUtil.showActivityAtIndex;
 import static gomedic.testutil.TypicalIndexes.INDEX_FIRST;
 import static gomedic.testutil.TypicalPersons.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import gomedic.logic.commands.Command;
+import gomedic.logic.commands.exceptions.CommandException;
 import gomedic.model.Model;
 import gomedic.model.ModelManager;
 import gomedic.model.UserPrefs;
@@ -24,12 +27,54 @@ class ListActivityCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListActivityCommand(), model, ListActivityCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListActivityCommand(ListActivityCommand.Sort.ID,
+                        ListActivityCommand.Period.ALL), model,
+                ListActivityCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showActivityAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListActivityCommand(), model, ListActivityCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListActivityCommand(ListActivityCommand.Sort.ID,
+                        ListActivityCommand.Period.ALL), model,
+                ListActivityCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFilteredByStartTime_showsEverything() throws CommandException {
+        showActivityAtIndex(model, INDEX_FIRST);
+        Command command = new ListActivityCommand(ListActivityCommand.Sort.START,
+                ListActivityCommand.Period.ALL);
+        assertDoesNotThrow(() -> command.execute(model));
+    }
+
+    @Test
+    public void execute_listIsFilteredById_showsEverything() {
+        showActivityAtIndex(model, INDEX_FIRST);
+        Command command = new ListActivityCommand(ListActivityCommand.Sort.START,
+                ListActivityCommand.Period.ALL);
+        Command finalCommand = command;
+        assertDoesNotThrow(() -> finalCommand.execute(model));
+
+        command = new ListActivityCommand(ListActivityCommand.Sort.START,
+                ListActivityCommand.Period.TODAY);
+        Command finalCommand1 = command;
+        assertDoesNotThrow(() -> finalCommand1.execute(model));
+
+        command = new ListActivityCommand(ListActivityCommand.Sort.START,
+                ListActivityCommand.Period.WEEK);
+        Command finalCommand2 = command;
+        assertDoesNotThrow(() -> finalCommand2.execute(model));
+
+        command = new ListActivityCommand(ListActivityCommand.Sort.START,
+                ListActivityCommand.Period.MONTH);
+        Command finalCommand3 = command;
+        assertDoesNotThrow(() -> finalCommand3.execute(model));
+
+
+        command = new ListActivityCommand(ListActivityCommand.Sort.START,
+                ListActivityCommand.Period.YEAR);
+        Command finalCommand4 = command;
+        assertDoesNotThrow(() -> finalCommand3.execute(model));
     }
 }

--- a/src/test/java/gomedic/logic/parser/ParserUtilTest.java
+++ b/src/test/java/gomedic/logic/parser/ParserUtilTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import gomedic.logic.commands.listcommand.ListActivityCommand;
 import gomedic.logic.parser.exceptions.ParseException;
 import gomedic.model.activity.ActivityId;
 import gomedic.model.activity.Description;
@@ -461,5 +462,42 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, () -> ParserUtil.parseId("B001"));
         assertThrows(ParseException.class, () -> ParserUtil.parseId("X001"));
         assertThrows(ParseException.class, () -> ParserUtil.parseId("Z9999"));
+    }
+
+    @Test
+    void parseSortActivityFlags_valid_testPassed() throws ParseException {
+        assertEquals(ParserUtil.parseSortActivityFlags("id"), ListActivityCommand.Sort.ID);
+        assertEquals(ParserUtil.parseSortActivityFlags("ID"), ListActivityCommand.Sort.ID);
+        assertEquals(ParserUtil.parseSortActivityFlags("start"), ListActivityCommand.Sort.START);
+        assertEquals(ParserUtil.parseSortActivityFlags("START"), ListActivityCommand.Sort.START);
+
+    }
+
+    @Test
+    void parseSortActivityFlags_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseSortActivityFlags("Z9999"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseSortActivityFlags("endtime"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseSortActivityFlags("i d"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseSortActivityFlags("start time"));
+    }
+
+    @Test
+    void parsePeriodActivityFlags_valid_testPassed() throws ParseException {
+        assertEquals(ParserUtil.parsePeriodActivityFlags("today"), ListActivityCommand.Period.TODAY);
+        assertEquals(ParserUtil.parsePeriodActivityFlags("ALL"), ListActivityCommand.Period.ALL);
+        assertEquals(ParserUtil.parsePeriodActivityFlags("TODAY"), ListActivityCommand.Period.TODAY);
+        assertEquals(ParserUtil.parsePeriodActivityFlags("toDAY"), ListActivityCommand.Period.TODAY);
+        assertEquals(ParserUtil.parsePeriodActivityFlags("WEEK"), ListActivityCommand.Period.WEEK);
+        assertEquals(ParserUtil.parsePeriodActivityFlags("year"), ListActivityCommand.Period.YEAR);
+        assertEquals(ParserUtil.parsePeriodActivityFlags("MONTH"), ListActivityCommand.Period.MONTH);
+    }
+
+    @Test
+    void parsePeriodActivityFlags_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePeriodActivityFlags("Z9999"));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePeriodActivityFlags("tommorow"));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePeriodActivityFlags("yesterday"));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePeriodActivityFlags("oneday"));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePeriodActivityFlags("15/9/2020 15:00"));
     }
 }

--- a/src/test/java/gomedic/logic/parser/listcommandparser/ListActivityParserTest.java
+++ b/src/test/java/gomedic/logic/parser/listcommandparser/ListActivityParserTest.java
@@ -1,0 +1,80 @@
+package gomedic.logic.parser.listcommandparser;
+
+import org.junit.jupiter.api.Test;
+
+import gomedic.logic.commands.CommandTestUtil;
+import gomedic.logic.commands.listcommand.ListActivityCommand;
+import gomedic.logic.parser.CommandParserTestUtil;
+
+public class ListActivityParserTest {
+    private final ListActivityParser parser = new ListActivityParser();
+
+    @Test
+    public void parse_allDefault_success() {
+        CommandParserTestUtil.assertParseSuccess(parser,
+                CommandTestUtil.PREAMBLE_WHITESPACE,
+                new ListActivityCommand(ListActivityCommand.Sort.ID, ListActivityCommand.Period.ALL));
+
+    }
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        // whitespace only preamble
+        CommandParserTestUtil.assertParseSuccess(parser,
+                CommandTestUtil.PREAMBLE_WHITESPACE
+                        + CommandTestUtil.VALID_SORT_FLAG_ID
+                        + CommandTestUtil.VALID_PERIOD_FLAG_ALL,
+                new ListActivityCommand(ListActivityCommand.Sort.ID, ListActivityCommand.Period.ALL));
+
+        // multiple start flag
+        CommandParserTestUtil.assertParseSuccess(parser,
+                CommandTestUtil.VALID_SORT_FLAG_START
+                        + CommandTestUtil.VALID_SORT_FLAG_ID
+                        + CommandTestUtil.VALID_PERIOD_FLAG_ALL,
+                new ListActivityCommand(ListActivityCommand.Sort.ID, ListActivityCommand.Period.ALL));
+
+        // multiple period flag
+        CommandParserTestUtil.assertParseSuccess(parser,
+                CommandTestUtil.VALID_SORT_FLAG_START
+                        + CommandTestUtil.VALID_PERIOD_FLAG_ALL
+                        + CommandTestUtil.VALID_PERIOD_FLAG_TODAY
+                , new ListActivityCommand(ListActivityCommand.Sort.START, ListActivityCommand.Period.TODAY));
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        CommandParserTestUtil.assertParseSuccess(parser,
+                CommandTestUtil.PREAMBLE_WHITESPACE
+                        + CommandTestUtil.VALID_PERIOD_FLAG_TODAY,
+                new ListActivityCommand(ListActivityCommand.Sort.ID, ListActivityCommand.Period.TODAY));
+
+        CommandParserTestUtil.assertParseSuccess(parser,
+                CommandTestUtil.PREAMBLE_WHITESPACE
+                        + CommandTestUtil.VALID_SORT_FLAG_ID,
+                new ListActivityCommand(ListActivityCommand.Sort.ID, ListActivityCommand.Period.ALL));
+
+        // random flags, ignore irrelevant flags.
+        CommandParserTestUtil.assertParseSuccess(parser,
+                CommandTestUtil.INVALID_DESC_DESCRIPTION,
+                new ListActivityCommand(ListActivityCommand.Sort.ID, ListActivityCommand.Period.ALL));
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid sort flag
+        CommandParserTestUtil.assertParseFailure(parser,
+                CommandTestUtil.INVALID_SORT_FLAG,
+                ListActivityCommand.Sort.MESSAGE_CONSTRAINTS + "\n" + ListActivityCommand.MESSAGE_USAGE);
+
+        // invalid period flag
+        CommandParserTestUtil.assertParseFailure(parser,
+                CommandTestUtil.INVALID_PERIOD_FLAG,
+                ListActivityCommand.Period.MESSAGE_CONSTRAINTS + "\n" + ListActivityCommand.MESSAGE_USAGE);
+
+        // both invalid period and sort flag
+        CommandParserTestUtil.assertParseFailure(parser,
+                CommandTestUtil.INVALID_SORT_FLAG
+                        + CommandTestUtil.INVALID_PERIOD_FLAG,
+                ListActivityCommand.Sort.MESSAGE_CONSTRAINTS + "\n" + ListActivityCommand.MESSAGE_USAGE);
+    }
+}

--- a/src/test/java/gomedic/logic/parser/listcommandparser/ListActivityParserTest.java
+++ b/src/test/java/gomedic/logic/parser/listcommandparser/ListActivityParserTest.java
@@ -37,8 +37,8 @@ public class ListActivityParserTest {
         CommandParserTestUtil.assertParseSuccess(parser,
                 CommandTestUtil.VALID_SORT_FLAG_START
                         + CommandTestUtil.VALID_PERIOD_FLAG_ALL
-                        + CommandTestUtil.VALID_PERIOD_FLAG_TODAY
-                , new ListActivityCommand(ListActivityCommand.Sort.START, ListActivityCommand.Period.TODAY));
+                        + CommandTestUtil.VALID_PERIOD_FLAG_TODAY,
+                new ListActivityCommand(ListActivityCommand.Sort.START, ListActivityCommand.Period.TODAY));
     }
 
     @Test

--- a/src/test/java/gomedic/model/AddressBookTest.java
+++ b/src/test/java/gomedic/model/AddressBookTest.java
@@ -54,7 +54,7 @@ public class AddressBookTest {
         assertEquals(Collections.emptyList(), addressBook.getDoctorListSortedById());
         assertEquals(Collections.emptyList(), addressBook.getPatientListSortedById());
         assertEquals(Collections.emptyList(), addressBook.getActivityListSortedById());
-        assertEquals(Collections.emptyList(), addressBook.getActivityListSortedStartTime());
+        assertEquals(Collections.emptyList(), addressBook.getActivityListSortedByStartTime());
     }
 
     @Test
@@ -230,7 +230,7 @@ public class AddressBookTest {
 
     @Test
     public void getActivityListSortedStartTime_call_returnsTrue() {
-        assertDoesNotThrow(addressBook::getActivityListSortedStartTime);
+        assertDoesNotThrow(addressBook::getActivityListSortedByStartTime);
     }
 
     @Test
@@ -239,7 +239,7 @@ public class AddressBookTest {
         addressBook.addActivity(PAST_ACTIVITY);
         addressBook.addActivity(MEETING);
 
-        assertEquals(List.of(PAST_ACTIVITY, MEETING), addressBook.getActivityListSortedStartTime());
+        assertEquals(List.of(PAST_ACTIVITY, MEETING), addressBook.getActivityListSortedByStartTime());
     }
 
     @Test
@@ -404,7 +404,7 @@ public class AddressBookTest {
         }
 
         @Override
-        public ObservableList<Activity> getActivityListSortedStartTime() {
+        public ObservableList<Activity> getActivityListSortedByStartTime() {
             return activities.sorted();
         }
     }

--- a/src/test/java/gomedic/model/ModelManagerTest.java
+++ b/src/test/java/gomedic/model/ModelManagerTest.java
@@ -272,7 +272,7 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredActivityList_modifyList_throwsUnsupportedOperationException() {
-        Assert.assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredActivityList()
+        Assert.assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredActivityListById()
                 .remove(0));
     }
 


### PR DESCRIPTION
### Summary

* Resolves #152 
* Now can be sorted by `startTime` and `id`
* Also, activities that is only today, in the coming week, month and year can be shown (filtered by specific timeframe)

### Detail

* Add a new list in the model called sortedActivityList 
* Update the UI model numbering too 

### Pictures / Gif
![image](https://user-images.githubusercontent.com/51783522/137631592-2e16c992-0d12-4796-894a-5e00f9e1b85e.png)



### Checks

- [x] Link PR to issue
- [x] Add Reviewer
- [x] Pass CI
