### PR TITLE
Fix medical bug if there is no condition

### DIFF
--- a/src/main/java/gomedic/logic/commands/ReferralCommand.java
+++ b/src/main/java/gomedic/logic/commands/ReferralCommand.java
@@ -186,7 +186,7 @@ public class ReferralCommand extends Command {
 
         String firstParaTemplate = "I would like to refer %s. %s to your clinic for a "
                 + "check-up as well as urgent treatment. "
-                + "%s is a %s years old%s. "
+                + "%s is %s years old%s. "
                 + "I am afraid that I do not have the necessary resources "
                 + "to treat %s as %s requires according to %s condition. \n";
 


### PR DESCRIPTION
### Summary

* Resolves #179 

### Detail

Make the sentence optional for medical conditions, if there is no tag, there we don't put the sentence. 

### Pictures / Gif

![image](https://user-images.githubusercontent.com/51783522/138680042-f93bab1f-a534-4bbb-bc21-e16a52f81fdb.png)

### Checks

- [x] Link PR to issue
- [x] Add Reviewer
- [x] Pass CI
