### PR TITLE
Fix bug that clear t/patient does not remove appropriate activities

### DIFF
--- a/src/main/java/gomedic/logic/commands/clearcommand/ClearPatientCommand.java
+++ b/src/main/java/gomedic/logic/commands/clearcommand/ClearPatientCommand.java
@@ -10,9 +10,11 @@ import gomedic.model.AddressBook;
 import gomedic.model.Model;
 import gomedic.model.ModelItem;
 import gomedic.model.ReadOnlyAddressBook;
+import gomedic.model.person.patient.Patient;
+import javafx.collections.ObservableList;
 
 /**
- * Clears the address book.
+ * Clears the address book of patients and associated activities.
  */
 public class ClearPatientCommand extends Command {
 
@@ -23,6 +25,10 @@ public class ClearPatientCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        ObservableList<Patient> listOfPatients = model.getFilteredPatientList();
+        for (Patient patient : listOfPatients) {
+            model.deletePatientAssociatedAppointments(patient);
+        }
         AddressBook newAddressBook = new AddressBook();
         ReadOnlyAddressBook oldAddressBook = model.getAddressBook();
         newAddressBook.setActivities(oldAddressBook.getActivityListSortedById());

--- a/src/test/java/gomedic/logic/commands/clearcommand/ClearPatientCommandTest.java
+++ b/src/test/java/gomedic/logic/commands/clearcommand/ClearPatientCommandTest.java
@@ -10,6 +10,9 @@ import gomedic.model.Model;
 import gomedic.model.ModelManager;
 import gomedic.model.ReadOnlyAddressBook;
 import gomedic.model.UserPrefs;
+import gomedic.model.activity.Activity;
+import gomedic.testutil.modelbuilder.ActivityBuilder;
+import javafx.collections.ObservableList;
 
 public class ClearPatientCommandTest {
 
@@ -28,7 +31,18 @@ public class ClearPatientCommandTest {
         AddressBook newAddressBook = new AddressBook();
         ReadOnlyAddressBook oldAddressBook = model.getAddressBook();
         newAddressBook.setDoctors(oldAddressBook.getDoctorListSortedById());
-        newAddressBook.setActivities(oldAddressBook.getActivityListSortedById());
+        Activity activityWithMatchingPatient = new ActivityBuilder()
+                .withId(5)
+                .withPatientId(1)
+                .withTitle("Meeting me")
+                .withDescription("today at somewhere")
+                .withStartTime("20/09/2022 13:00")
+                .withEndTime("21/09/2022 15:00")
+                .build();
+        ObservableList<Activity> remainingActivities = oldAddressBook.getActivityListSortedById()
+                .filtered(x -> !x.equals(activityWithMatchingPatient));
+        newAddressBook.setActivities(remainingActivities);
+
         expectedModel.setAddressBook(newAddressBook);
 
         assertCommandSuccess(new ClearPatientCommand(), model, ClearPatientCommand.MESSAGE_SUCCESS, expectedModel);


### PR DESCRIPTION
### Summary

Resolves #180 

Fixes bug where clear t/patient does not remove related activities. missed out modification of clear command.

### Detail

Not much to say

### Pictures / Gif

### Checks

- [ ] Link PR to issue
- [ ] Add Reviewer
- [ ] Pass CI
