### PR TITLE
Resolves different date being shown bug when date is invalid 

### DIFF
--- a/src/main/java/gomedic/model/commonfield/Time.java
+++ b/src/main/java/gomedic/model/commonfield/Time.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 
 import gomedic.commons.util.AppUtil;
 
@@ -42,11 +43,17 @@ public class Time {
         DateTimeFormatter format;
 
         if (time.charAt(2) == '/') {
-            format = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+            format = DateTimeFormatter
+                    .ofPattern("dd/MM/yyyy HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
         } else if (time.charAt(2) == '-') {
-            format = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+            format = DateTimeFormatter
+                    .ofPattern("dd-MM-yyyy HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
         } else {
-            format = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            format = DateTimeFormatter
+                    .ofPattern("yyyy-MM-dd HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
         }
 
         this.time = LocalDateTime.parse(time, format);

--- a/src/test/java/gomedic/model/commonfield/TimeTest.java
+++ b/src/test/java/gomedic/model/commonfield/TimeTest.java
@@ -32,6 +32,7 @@ class TimeTest {
         assertThrows(IllegalArgumentException.class, () -> new Time("-1-12-2022 13:00"));
         assertThrows(IllegalArgumentException.class, () -> new Time("00-01-2022 13:00"));
         assertThrows(IllegalArgumentException.class, () -> new Time("ab-12-2015 13:00"));
+        assertThrows(IllegalArgumentException.class, () -> new Time("29-02-2022 13:00")); // invalid feb date
     }
 
     @Test

--- a/src/test/java/gomedic/model/commonfield/TimeTest.java
+++ b/src/test/java/gomedic/model/commonfield/TimeTest.java
@@ -52,6 +52,7 @@ class TimeTest {
     @Test
     public void constructor_invalidMinute_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new Time("15/12/2022 13:61"));
+        assertThrows(IllegalArgumentException.class, () -> new Time("15/12/2022 12:61"));
         assertThrows(IllegalArgumentException.class, () -> new Time("15/12/2022 13:1"));
     }
 


### PR DESCRIPTION
### Summary

* Resolve #274 

### Detail

* This is because the time is in `SMART` mode where is tries to interpret what is the closest valid date compared to that invalid date, using strict mode, these invalid dates would be immediately flagged as false
* Updated error message

### Pictures / Gif

![image](https://user-images.githubusercontent.com/51783522/139570033-ce9ee49f-5a0b-4f62-8ab6-fbf3e28d6c52.png)

### Checks

- [x] Link PR to issue
- [x] Add Reviewer
- [x] Pass CI
